### PR TITLE
Move to Swift 6 Language Mode for Control Plane

### DIFF
--- a/control-plane/Package.swift
+++ b/control-plane/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
             swiftSettings: swiftSettings
         )
     ],
-    swiftLanguageModes: [.v5]
+    swiftLanguageModes: [.v6]
 )
 
 var swiftSettings: [SwiftSetting] {

--- a/control-plane/Sources/App/Controllers/AgentWebSocketController.swift
+++ b/control-plane/Sources/App/Controllers/AgentWebSocketController.swift
@@ -8,20 +8,20 @@ struct AgentWebSocketController: RouteCollection {
         let agentRoutes = routes.grouped("agent")
         agentRoutes.webSocket("ws", onUpgrade: websocketHandler)
     }
-    
+
     private func websocketHandler(req: Request, ws: WebSocket) {
         req.logger.info("Agent WebSocket connection established")
-        
+
         ws.onText { ws, text in
             Task {
                 await handleWebSocketMessage(req: req, ws: ws, text: text)
             }
         }
-        
+
         ws.onBinary { ws, buffer in
             req.logger.warning("Received unexpected binary data from agent")
         }
-        
+
         ws.onClose.whenComplete { result in
             switch result {
             case .success:
@@ -31,67 +31,67 @@ struct AgentWebSocketController: RouteCollection {
             }
         }
     }
-    
+
     private func handleWebSocketMessage(req: Request, ws: WebSocket, text: String) async {
         do {
             guard let data = text.data(using: .utf8) else {
                 req.logger.error("Failed to convert WebSocket text to data")
                 return
             }
-            
+
             let envelope = try JSONDecoder().decode(MessageEnvelope.self, from: data)
-            
+
             switch envelope.type {
             case .agentRegister:
                 let message = try envelope.decode(as: AgentRegisterMessage.self)
                 await req.agentService.registerAgent(message, websocket: ws)
                 await sendSuccessResponse(ws: ws, requestId: message.requestId, message: "Agent registered successfully")
-                
+
             case .agentHeartbeat:
                 let message = try envelope.decode(as: AgentHeartbeatMessage.self)
                 await req.agentService.updateAgentHeartbeat(message)
                 await sendSuccessResponse(ws: ws, requestId: message.requestId, message: "Heartbeat acknowledged")
-                
+
             case .agentUnregister:
                 let message = try envelope.decode(as: AgentUnregisterMessage.self)
                 await req.agentService.unregisterAgent(message.agentId)
                 await sendSuccessResponse(ws: ws, requestId: message.requestId, message: "Agent unregistered successfully")
-                
+
             case .success, .error, .statusUpdate:
                 // Handle responses from agents
                 await req.agentService.handleAgentResponse(envelope)
-                
+
             default:
                 req.logger.warning("Received unexpected message type from agent: \(envelope.type)")
                 await sendErrorResponse(ws: ws, requestId: "", error: "Unexpected message type: \(envelope.type)")
             }
-            
+
         } catch {
             req.logger.error("Failed to handle WebSocket message: \(error)")
             await sendErrorResponse(ws: ws, requestId: "", error: "Failed to process message: \(error.localizedDescription)")
         }
     }
-    
+
     private func sendSuccessResponse(ws: WebSocket, requestId: String, message: String) async {
         do {
             let response = SuccessMessage(requestId: requestId, message: message)
             let envelope = try MessageEnvelope(message: response)
             let data = try JSONEncoder().encode(envelope)
-            
-            try await ws.send(data)
+
+            ws.send(data)
         } catch {
             // Log error but don't throw since we're already in an error handling context
             print("Failed to send success response: \(error)")
         }
     }
-    
+
     private func sendErrorResponse(ws: WebSocket, requestId: String, error: String) async {
         do {
             let response = ErrorMessage(requestId: requestId, error: error)
             let envelope = try MessageEnvelope(message: response)
             let data = try JSONEncoder().encode(envelope)
-            
-            try await ws.send(data)
+
+            ws.send(data)
         } catch {
             // Log error but don't throw since we're already in an error handling context
             print("Failed to send error response: \(error)")

--- a/control-plane/Sources/App/Models/Organization.swift
+++ b/control-plane/Sources/App/Models/Organization.swift
@@ -2,30 +2,30 @@ import Fluent
 import Vapor
 import Foundation
 
-final class Organization: Model {
+final class Organization: Model, @unchecked Sendable {
     static let schema = "organizations"
-    
+
     @ID(key: .id)
     var id: UUID?
-    
+
     @Field(key: "name")
     var name: String
-    
+
     @Field(key: "description")
     var description: String
-    
+
     @Timestamp(key: "created_at", on: .create)
     var createdAt: Date?
-    
+
     @Timestamp(key: "updated_at", on: .update)
     var updatedAt: Date?
-    
+
     // Relationships
     @Siblings(through: UserOrganization.self, from: \.$organization, to: \.$user)
     var users: [User]
-    
+
     init() {}
-    
+
     init(
         id: UUID? = nil,
         name: String,
@@ -41,26 +41,26 @@ extension Organization: Content {}
 
 // MARK: - User-Organization Relationship (Many-to-Many)
 
-final class UserOrganization: Model {
+final class UserOrganization: Model, @unchecked Sendable {
     static let schema = "user_organizations"
-    
+
     @ID(key: .id)
     var id: UUID?
-    
+
     @Parent(key: "user_id")
     var user: User
-    
+
     @Parent(key: "organization_id")
     var organization: Organization
-    
+
     @Field(key: "role")
     var role: String // "admin" or "member"
-    
+
     @Timestamp(key: "created_at", on: .create)
     var createdAt: Date?
-    
+
     init() {}
-    
+
     init(
         id: UUID? = nil,
         userID: UUID,
@@ -94,7 +94,7 @@ struct OrganizationResponse: Content {
     let description: String
     let createdAt: Date?
     let userRole: String?
-    
+
     init(from organization: Organization, userRole: String? = nil) {
         self.id = organization.id
         self.name = organization.name

--- a/control-plane/Sources/App/Models/User.swift
+++ b/control-plane/Sources/App/Models/User.swift
@@ -2,7 +2,7 @@ import Fluent
 import Vapor
 import Foundation
 
-final class User: Model {
+final class User: Model, @unchecked Sendable {
     static let schema = "users"
 
     @ID(key: .id)
@@ -58,7 +58,7 @@ extension User: SessionAuthenticatable {
 
 // MARK: - UserCredential Model for Passkeys
 
-final class UserCredential: Model {
+final class UserCredential: Model, @unchecked Sendable {
     static let schema = "user_credentials"
 
     @ID(key: .id)
@@ -128,7 +128,7 @@ extension UserCredential: Content {}
 
 // MARK: - Challenge Storage
 
-final class AuthenticationChallenge: Model {
+final class AuthenticationChallenge: Model, @unchecked Sendable {
     static let schema = "authentication_challenges"
 
     @ID(key: .id)

--- a/control-plane/Sources/App/Models/VMTemplate.swift
+++ b/control-plane/Sources/App/Models/VMTemplate.swift
@@ -1,7 +1,7 @@
 import Fluent
 import Vapor
 
-final class VMTemplate: Model {
+final class VMTemplate: Model, @unchecked Sendable {
     static let schema = "vm_templates"
 
     @ID(key: .id)
@@ -145,16 +145,16 @@ extension VMTemplate {
         if cpu < minCpu || cpu > maxCpu {
             throw VMTemplateError.cpuOutOfRange(min: minCpu, max: maxCpu, requested: cpu)
         }
-        
+
         if memory < minMemory || memory > maxMemory {
             throw VMTemplateError.memoryOutOfRange(min: minMemory, max: maxMemory, requested: memory)
         }
-        
+
         if disk < minDisk || disk > maxDisk {
             throw VMTemplateError.diskOutOfRange(min: minDisk, max: maxDisk, requested: disk)
         }
     }
-    
+
     func createVMInstance(
         name: String,
         description: String,
@@ -167,9 +167,9 @@ extension VMTemplate {
         let finalMemory = memory ?? defaultMemory
         let finalDisk = disk ?? defaultDisk
         let finalCmdline = cmdline ?? defaultCmdline
-        
+
         try validateResourceLimits(cpu: finalCpu, memory: finalMemory, disk: finalDisk)
-        
+
         return VM(
             name: name,
             description: description,
@@ -180,14 +180,14 @@ extension VMTemplate {
             maxCpu: finalCpu
         )
     }
-    
+
     func generateDiskPath(for vmId: UUID) -> String {
         let fileExtension = (baseDiskPath as NSString).pathExtension
         let fileName = "\(vmId.uuidString).\(fileExtension)"
         let baseDir = (baseDiskPath as NSString).deletingLastPathComponent
         return "\(baseDir)/\(fileName)"
     }
-    
+
     func generateMacAddress() -> String {
         if let prefix = defaultMacPrefix {
             let randomBytes = (0..<3).map { _ in String(format: "%02x", Int.random(in: 0...255)) }
@@ -208,7 +208,7 @@ enum VMTemplateError: Error, LocalizedError {
     case diskOutOfRange(min: Int64, max: Int64, requested: Int64)
     case templateNotFound(String)
     case templateInactive(String)
-    
+
     var errorDescription: String? {
         switch self {
         case .cpuOutOfRange(let min, let max, let requested):

--- a/control-plane/Sources/App/Models/vm.swift
+++ b/control-plane/Sources/App/Models/vm.swift
@@ -2,7 +2,7 @@ import Fluent
 import Vapor
 import StratoShared
 
-final class VM: Model {
+final class VM: Model, @unchecked Sendable {
     static let schema = "vms"
 
     @ID(key: .id)
@@ -174,31 +174,31 @@ extension VM {
     var memoryMB: Int {
         return Int(memory / 1024 / 1024)
     }
-    
+
     var memoryGB: Double {
         return Double(memory) / 1024.0 / 1024.0 / 1024.0
     }
-    
+
     var diskGB: Double {
         return Double(disk) / 1024.0 / 1024.0 / 1024.0
     }
-    
+
     var isRunning: Bool {
         return status == .running
     }
-    
+
     var canStart: Bool {
         return status == .created || status == .shutdown
     }
-    
+
     var canStop: Bool {
         return status == .running || status == .paused
     }
-    
+
     var canPause: Bool {
         return status == .running
     }
-    
+
     var canResume: Bool {
         return status == .paused
     }


### PR DESCRIPTION
- Fix warnings for the _id property wrapper for Vapor models based on [this](https://blog.vapor.codes/posts/fluent-models-and-sendable/)
- Switch to Swift 6 language mode for the control plane target
- Fix some more warnings