### PR TITLE
Upgrade Swift toolchain: tools-version 6.2, Swift 6 mode everywhere, 6.3.2 toolchain pins

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,6 +67,8 @@ jobs:
             ${{ runner.os }}-swift-
 
       - uses: vapor/swiftly-action@v0.2
+        with:
+          toolchain: "6.3.2"
 
       - name: Build Shared Package
         working-directory: shared

--- a/.github/workflows/main-build.yaml
+++ b/.github/workflows/main-build.yaml
@@ -55,6 +55,8 @@ jobs:
         run: bun run build:deploy
 
       - uses: vapor/swiftly-action@v0.2
+        with:
+          toolchain: "6.3.2"
 
       - name: Build Control Plane Release Binary
         working-directory: control-plane

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -199,9 +199,9 @@ jobs:
 
       - name: Set up Swift (Linux)
         if: matrix.os == 'self-hosted'
-        uses: swift-actions/setup-swift@v1
+        uses: vapor/swiftly-action@v0.2
         with:
-          swift-version: "6.0"
+          toolchain: "6.3.2"
 
       - name: Debug jemalloc
         if: matrix.os == 'self-hosted'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,7 +258,7 @@ The agent supports both Linux and macOS platforms with hardware-accelerated virt
 | **Production Ready** | ✅ Yes | ⚠️ Dev/Test only |
 
 ### Project Structure Notes
-- Swift strict concurrency enabled (Swift 6.0)
+- Swift strict concurrency enabled (Swift 6 language mode, swift-tools-version 6.2, upcoming features `InferIsolatedConformances` and `NonisolatedNonsendingByDefault` enabled)
 - Control Plane: Traditional Vapor web application with database
 - Agent: Cross-platform Swift application for hypervisor nodes
   - Linux: Production-ready with KVM and OVN/OVS

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/samcat116/strato/actions/workflows/build.yaml/badge.svg)](https://github.com/samcat116/strato/actions/workflows/build.yaml)
 [![License: FSL-1.1-MIT](https://img.shields.io/badge/License-FSL--1.1--MIT-blue.svg)](LICENSE.md)
-[![Swift 6.0](https://img.shields.io/badge/Swift-6.0-orange.svg)](https://swift.org)
+[![Swift 6.2](https://img.shields.io/badge/Swift-6.2%2B-orange.svg)](https://swift.org)
 [![Platform](https://img.shields.io/badge/Platform-macOS%2013%2B-lightgrey.svg)](https://www.apple.com/macos/)
 
 Strato is a fast, secure, and easy to deploy private cloud platform based on battle tested technologies and built for modern infrastructure. It enables operators to run efficient, secure, and powerful infrastructure easily.
@@ -21,7 +21,7 @@ Strato is a fast, secure, and easy to deploy private cloud platform based on bat
 
 ### Prerequisites
 
-- Swift 6.0 or later
+- Swift 6.2 or later
 - Docker and Docker Compose
 - PostgreSQL (if running locally)
 

--- a/SwiftFirecracker/Package.swift
+++ b/SwiftFirecracker/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.2
 import PackageDescription
 
 let package = Package(
@@ -23,6 +23,8 @@ let package = Package(
             ],
             swiftSettings: [
                 .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("InferIsolatedConformances"),
+                .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
             ]
         ),
         .testTarget(
@@ -30,6 +32,8 @@ let package = Package(
             dependencies: ["SwiftFirecracker"],
             swiftSettings: [
                 .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("InferIsolatedConformances"),
+                .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
             ]
         ),
     ]

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM swift:6.1.2-noble AS build
+FROM swift:6.3.2-noble AS build
 
 # Install OS updates
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \

--- a/agent/Package.resolved
+++ b/agent/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a3dc0b881383540cc0572f9f55887709f0d9266c8da6377fcbf1f6093663de86",
+  "originHash" : "c3510d8ea54e691d81546427cbca4514da52a9afa69b1347872f7c33e82a7baa",
   "pins" : [
     {
       "identity" : "swift-algorithms",
@@ -155,15 +155,6 @@
       }
     },
     {
-      "identity" : "swift-ovn",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/samcat116/swift-ovn.git",
-      "state" : {
-        "branch" : "main",
-        "revision" : "fe6364754f8d0e4a5ce8f01f42cf138f7899a9d9"
-      }
-    },
-    {
       "identity" : "swift-qemu",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/samcat116/swift-qemu",
@@ -182,30 +173,12 @@
       }
     },
     {
-      "identity" : "swift-syntax",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-syntax.git",
-      "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
-      }
-    },
-    {
       "identity" : "swift-system",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
         "revision" : "395a77f0aa927f0ff73941d7ac35f2b46d47c9db",
         "version" : "1.6.3"
-      }
-    },
-    {
-      "identity" : "swift-testing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-testing.git",
-      "state" : {
-        "revision" : "399f76dcd91e4c688ca2301fa24a8cc6d9927211",
-        "version" : "0.99.0"
       }
     },
     {

--- a/agent/Package.swift
+++ b/agent/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.2
 import PackageDescription
 
 let package = Package(
@@ -18,13 +18,13 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
         .package(url: "https://github.com/samcat116/swift-toml.git", branch: "master"),
-        .package(url: "https://github.com/apple/swift-testing.git", from: "0.10.0"),
     ] + platformPackageDependencies,
     targets: [
         // Core library with testable code (no SwiftQEMU dependency)
         .target(
             name: "StratoAgentCore",
             dependencies: [
+                .product(name: "StratoShared", package: "shared"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Toml", package: "swift-toml"),
             ],
@@ -49,16 +49,18 @@ let package = Package(
             name: "StratoAgentTests",
             dependencies: [
                 "StratoAgentCore",
-                .product(name: "Testing", package: "swift-testing"),
             ],
             swiftSettings: swiftSettings
         )
     ],
-    swiftLanguageModes: [.v5]
+    swiftLanguageModes: [.v6]
 )
 
 var swiftSettings: [SwiftSetting] {
-    []
+    [
+        .enableUpcomingFeature("InferIsolatedConformances"),
+        .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+    ]
 }
 
 // Conditional dependencies based on platform

--- a/agent/Sources/StratoAgent/Agent.swift
+++ b/agent/Sources/StratoAgent/Agent.swift
@@ -362,7 +362,7 @@ actor Agent {
 
             // Set up timeout
             Task {
-                try await Task.sleep(for: .seconds(30))
+                try? await Task.sleep(for: .seconds(30))
                 if self.registrationContinuation != nil {
                     self.registrationContinuation?.resume(throwing: AgentError.registrationTimeout)
                     self.registrationContinuation = nil

--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image - only for local builds
 # ================================
-FROM swift:6.1.2-noble AS build
+FROM swift:6.3.2-noble AS build
 
 # Check if we're using prebuilt artifacts
 ARG PREBUILT_ARTIFACTS=""

--- a/control-plane/Package.resolved
+++ b/control-plane/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6bf10600b44ff9e7277dfb3a96b8ae04967d053f585fd76e318957594b645f0a",
+  "originHash" : "1e1cb982a48c875bb198d567e1b848d15a09350c2af3924ffc6009d2e711d808",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -231,8 +231,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-async-algorithms.git",
       "state" : {
-        "revision" : "6c050d5ef8e1aa6342528460db614e9770d7f804",
-        "version" : "1.1.1"
+        "revision" : "9d349bcc328ac3c31ce40e746b5882742a0d1272",
+        "version" : "1.1.3"
       }
     },
     {

--- a/control-plane/Package.swift
+++ b/control-plane/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.1
+// swift-tools-version:6.2
 import PackageDescription
 
 let package = Package(
@@ -70,13 +70,24 @@ let package = Package(
                 .product(name: "VaporTesting", package: "vapor"),
                 .product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver")
             ],
-            swiftSettings: swiftSettings
+            swiftSettings: testSwiftSettings
         )
     ],
     swiftLanguageModes: [.v6]
 )
 
 var swiftSettings: [SwiftSetting] {
-    // Minimal settings for Swift 6 compatibility
-    []
+    [
+        .enableUpcomingFeature("InferIsolatedConformances"),
+        .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+    ]
+}
+
+// VaporTesting's request/response closures are not yet compatible with
+// NonisolatedNonsendingByDefault, so the test target only gets the
+// non-behavioral feature.
+var testSwiftSettings: [SwiftSetting] {
+    [
+        .enableUpcomingFeature("InferIsolatedConformances"),
+    ]
 }

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -28,7 +28,7 @@ This guide will help you set up Strato for development or production use.
 
 ### Swift Development (Optional)
 
-- Swift 6.0 or later
+- Swift 6.2 or later
 - Vapor CLI (optional): `brew install vapor`
 
 ## Installation

--- a/shared/Package.swift
+++ b/shared/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.2
 import PackageDescription
 
 let package = Package(
@@ -23,6 +23,10 @@ let package = Package(
             dependencies: [
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOWebSocket", package: "swift-nio"),
+            ],
+            swiftSettings: [
+                .enableUpcomingFeature("InferIsolatedConformances"),
+                .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
             ]
         )
     ],


### PR DESCRIPTION
## Summary

Modernizes the Swift toolchain setup across all four packages so the project builds with the Swift 6.4 beta locally (Xcode 27) while pinning the latest *released* toolchain (6.3.2) for Docker and CI, and adopts the Swift 6.2+ concurrency features that make sense for server-side code.

> **Why 6.3.2 and not 6.4 in CI/Docker?** Swift 6.4 has not shipped yet — `release/6.4.x` branched in May 2026 and only snapshot toolchains exist; there are no `swift:6.4` Docker images. The local 6.4 toolchain comes from the Xcode 27 beta. When 6.4 GA lands, the bump is just the Docker tags and the CI `toolchain` pins.

### Manifests (all packages → `swift-tools-version:6.2`)
- **Agent moves from Swift 5 to Swift 6 language mode** — zero source changes were needed; the code was already actor-based. All 29 tests pass.
- Drops the pre-release `swift-testing` 0.10.0 dependency in favor of the toolchain-bundled Swift Testing (also removes the heavy `swift-syntax` checkout from the agent's graph).
- Enables upcoming features `InferIsolatedConformances` and `NonisolatedNonsendingByDefault` (SE-0461) on first-party targets — the server-appropriate half of "Approachable Concurrency" and the eventual language default. `defaultIsolation(MainActor.self)` is deliberately **not** used (it targets UI apps and would serialize the Vapor server).
- Exception: the control-plane test target only gets `InferIsolatedConformances`, because VaporTesting's `beforeRequest`/`afterResponse` closures are not yet compatible with the new isolation default.

### Bugs surfaced by the newer compiler (fixed)
- `StratoAgentCore` imported `StratoShared` without declaring the dependency; the old SwiftPM build system leaked modules between targets, the new Swift Build system correctly rejects it.
- `swift-async-algorithms` 1.1.1 (transitive dep of the control plane) fails newer region-isolation checking; bumped to 1.1.3.
- The agent's registration-timeout `Task` silently dropped its sleep error (new `NoUseUnstructuredThrowingTask` diagnostic in 6.4); now handled explicitly.

### Infrastructure
- Dockerfiles: `swift:6.1.2-noble` → `swift:6.3.2-noble`.
- `release.yaml`: `swift-actions/setup-swift@v1` + Swift 6.0 → `vapor/swiftly-action@v0.2` + `toolchain: "6.3.2"` (setup-swift v2's hardcoded version list tops out at 6.2.1).
- `build.yaml` / `main-build.yaml`: pin the previously unpinned swiftly-action steps to 6.3.2.
- Docs/README/CLAUDE.md updated to Swift 6.2+ minimum.

### Behavioral note
`NonisolatedNonsendingByDefault` changes runtime behavior: `nonisolated async` functions now run on the caller's actor instead of always hopping to the global executor. This codebase is IO-bound (sockets, QMP, HTTP) and all test suites pass; future compute-heavy async helpers should be marked `@concurrent`.

## Test plan
- [x] `shared`, `SwiftFirecracker`, `agent`, `control-plane` all build with the Swift 6.4 beta toolchain
- [x] Agent: 29/29 tests pass (Swift 6 mode, bundled Swift Testing, clean build)
- [x] SwiftFirecracker: 7/7 tests pass
- [x] Control plane: 228/228 tests pass
- [ ] Docker image builds on `swift:6.3.2-noble` (exercised by CI on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)