### PR TITLE
Fix control plane↔agent correlation, reliability, and VM state reconciliation

### DIFF
--- a/agent/Package.resolved
+++ b/agent/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c3510d8ea54e691d81546427cbca4514da52a9afa69b1347872f7c33e82a7baa",
+  "originHash" : "2f69361e9a84af71d1856fe6eff7f129a8ac106581f4876783022e5c5752256f",
   "pins" : [
     {
       "identity" : "swift-algorithms",
@@ -152,6 +152,15 @@
       "state" : {
         "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
         "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-ovn",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/samcat116/swift-ovn.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "df0ca243703e7a1fad3f7897a0a67a060ff9d1cf"
       }
     },
     {

--- a/agent/Sources/StratoAgent/Agent.swift
+++ b/agent/Sources/StratoAgent/Agent.swift
@@ -41,6 +41,7 @@ actor Agent {
     private var volumeService: VolumeService?
     private var consoleSocketManager: ConsoleSocketManager?
     private var heartbeatTask: Task<Void, Error>?
+    private var reconnectTask: Task<Void, Never>?
     private var isRunning = false
     private var registrationContinuation: CheckedContinuation<String, Error>?
     private let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 2)
@@ -238,7 +239,10 @@ actor Agent {
     func stop() async {
         logger.info("Stopping agent")
         isRunning = false
-        
+
+        reconnectTask?.cancel()
+        reconnectTask = nil
+
         heartbeatTask?.cancel()
         heartbeatTask = nil
         
@@ -423,6 +427,54 @@ actor Agent {
             }
         }
     }
+
+    // MARK: - Reconnection
+
+    /// Called by the WebSocket client when the connection to the control plane drops
+    /// unexpectedly. Starts a single reconnection loop (guarded against duplicates).
+    func handleConnectionLost() async {
+        guard isRunning else { return }
+        guard reconnectTask == nil else {
+            logger.debug("Reconnection already in progress; ignoring duplicate signal")
+            return
+        }
+
+        logger.warning("Lost connection to control plane; beginning reconnection with backoff")
+        reconnectTask = Task { [weak self] in
+            await self?.runReconnectLoop()
+        }
+    }
+
+    /// Repeatedly attempts to reconnect to the control plane with exponential backoff
+    /// and jitter, re-registering on success. Runs until reconnected or the agent stops.
+    private func runReconnectLoop() async {
+        defer { reconnectTask = nil }
+
+        var delaySeconds = 1.0
+        let maxDelaySeconds = 30.0
+
+        while isRunning {
+            // Backoff with jitter to avoid thundering-herd reconnects across many agents.
+            let jitter = Double.random(in: 0...(delaySeconds * 0.3))
+            do {
+                try await Task.sleep(for: .seconds(delaySeconds + jitter))
+            } catch {
+                return // cancelled (agent stopping)
+            }
+
+            guard isRunning else { return }
+
+            do {
+                try await websocketClient?.connect()
+                try await registerWithControlPlane()
+                logger.info("Successfully reconnected and re-registered with control plane")
+                return
+            } catch {
+                logger.error("Reconnection attempt failed, will retry: \(error)")
+                delaySeconds = min(delaySeconds * 2, maxDelaySeconds)
+            }
+        }
+    }
     
     func sendHeartbeat() async {
         do {
@@ -455,15 +507,49 @@ actor Agent {
     }
     
     private func getAgentResources() async -> AgentResources {
-        // TODO: Implement actual resource detection
-        // For now, return mock values
+        // Host capacity, probed live from the machine the agent runs on.
+        let totalCPU = HostResources.logicalCoreCount
+        let totalMemory = HostResources.physicalMemoryBytes
+
+        // Resources committed to VMs currently managed on this host. We report
+        // available = total - reserved (1:1, no overcommit) so the scheduler treats
+        // CPU/memory as hard constraints; overcommit ratios can be layered on later.
+        var reservedCPU = 0
+        var reservedMemory: Int64 = 0
+
+        if let qemu = qemuService {
+            let reserved = await qemu.reservedResources()
+            reservedCPU += reserved.vcpus
+            reservedMemory += reserved.memoryBytes
+        }
+
+        #if os(Linux)
+        if let firecracker = firecrackerService {
+            let reserved = await firecracker.reservedResources()
+            reservedCPU += reserved.vcpus
+            reservedMemory += reserved.memoryBytes
+        }
+        #endif
+
+        let availableCPU = max(0, totalCPU - reservedCPU)
+        let availableMemory = max(0, totalMemory - reservedMemory)
+
+        // VM disks are created directly on the storage filesystem, so query it live
+        // rather than tracking reservations — this naturally accounts for existing disks.
+        let disk = HostResources.diskCapacity(forPath: vmStoragePath)
+        if disk == nil {
+            logger.warning("Unable to determine disk capacity for VM storage path", metadata: [
+                "path": .string(vmStoragePath)
+            ])
+        }
+
         return AgentResources(
-            totalCPU: 8,
-            availableCPU: 6,
-            totalMemory: 16 * 1024 * 1024 * 1024, // 16GB
-            availableMemory: 12 * 1024 * 1024 * 1024, // 12GB
-            totalDisk: 1000 * 1024 * 1024 * 1024, // 1TB
-            availableDisk: 800 * 1024 * 1024 * 1024 // 800GB
+            totalCPU: totalCPU,
+            availableCPU: availableCPU,
+            totalMemory: totalMemory,
+            availableMemory: availableMemory,
+            totalDisk: disk?.total ?? 0,
+            availableDisk: disk?.free ?? 0
         )
     }
     

--- a/agent/Sources/StratoAgent/Agent.swift
+++ b/agent/Sources/StratoAgent/Agent.swift
@@ -489,6 +489,11 @@ actor Agent {
                 return
             } catch {
                 logger.error("Reconnection attempt failed, will retry: \(error)")
+                // Tear down any half-open socket from this attempt (connect succeeded
+                // but registration failed or timed out) so the next attempt starts
+                // from a clean state instead of stacking connections. disconnect()
+                // marks the close intentional, so it won't trigger a second loop.
+                await websocketClient?.disconnect()
                 delaySeconds = min(delaySeconds * 2, maxDelaySeconds)
             }
         }

--- a/agent/Sources/StratoAgent/Agent.swift
+++ b/agent/Sources/StratoAgent/Agent.swift
@@ -27,6 +27,10 @@ actor Agent {
     private let initialAgentID: String  // ID used for registration (hostname or CLI arg)
     private var assignedAgentID: String?  // UUID assigned by control plane after registration
     private let webSocketURL: String
+    // The URL to dial, including any rotated registration token. Registration tokens
+    // are single-use, so the control plane returns a fresh one on each successful
+    // registration and this tracks it for the reconnect loop.
+    private var currentWebSocketURL: String
     private let qemuSocketDir: String
     private let isRegistrationMode: Bool
     private let logger: Logger
@@ -80,6 +84,7 @@ actor Agent {
     ) {
         self.initialAgentID = agentID
         self.webSocketURL = webSocketURL
+        self.currentWebSocketURL = webSocketURL
         self.qemuSocketDir = qemuSocketDir
         self.networkMode = networkMode
         self.isRegistrationMode = isRegistrationMode
@@ -215,7 +220,7 @@ actor Agent {
         } else {
             logger.info("Connecting to control plane", metadata: ["url": .string(webSocketURL)])
         }
-        websocketClient = WebSocketClient(url: webSocketURL, agent: self, logger: logger, tlsConfiguration: tlsConfiguration)
+        websocketClient = WebSocketClient(url: currentWebSocketURL, agent: self, logger: logger, tlsConfiguration: tlsConfiguration)
 
         if let client = websocketClient {
             try await client.connect()
@@ -379,7 +384,20 @@ actor Agent {
     }
 
     /// Handle registration response from control plane
-    func handleRegistrationResponse(_ response: AgentRegisterResponseMessage) {
+    func handleRegistrationResponse(_ response: AgentRegisterResponseMessage) async {
+        // Adopt the rotated reconnect token (if any) before resuming registration:
+        // the token this connection presented was consumed by the control plane, so
+        // the reconnect loop must dial with the fresh one to be accepted.
+        if let rotatedToken = response.reconnectToken {
+            if let updatedURL = WebSocketURLs.replacingTokenQueryParameter(in: currentWebSocketURL, with: rotatedToken) {
+                currentWebSocketURL = updatedURL
+                await websocketClient?.updateURL(updatedURL)
+                logger.info("Adopted rotated reconnect token from control plane")
+            } else {
+                logger.warning("Control plane sent a reconnect token but the WebSocket URL has no token parameter; ignoring")
+            }
+        }
+
         guard let continuation = registrationContinuation else {
             logger.warning("Received registration response but no continuation waiting")
             return
@@ -586,7 +604,7 @@ extension Agent {
             switch envelope.type {
             case .agentRegisterResponse:
                 let message = try envelope.decode(as: AgentRegisterResponseMessage.self)
-                handleRegistrationResponse(message)
+                await handleRegistrationResponse(message)
             case .vmCreate:
                 let message = try envelope.decode(as: VMCreateMessage.self)
                 await handleVMCreate(message)

--- a/agent/Sources/StratoAgent/FirecrackerService.swift
+++ b/agent/Sources/StratoAgent/FirecrackerService.swift
@@ -264,8 +264,10 @@ actor FirecrackerService: HypervisorService {
     }
 
     func getVMStatus(vmId: String) async throws -> VMStatus {
+        // An absent entry means this service does not manage the VM at all; report
+        // that honestly instead of fabricating `.shutdown` (see QEMUService).
         guard let manager = vmManagers[vmId] else {
-            return .shutdown
+            throw HypervisorServiceError.vmNotFound(vmId)
         }
 
         let instanceInfo = try await manager.getInstanceInfo()

--- a/agent/Sources/StratoAgent/FirecrackerService.swift
+++ b/agent/Sources/StratoAgent/FirecrackerService.swift
@@ -284,6 +284,18 @@ actor FirecrackerService: HypervisorService {
         return Array(vmManagers.keys)
     }
 
+    /// Sum of vCPUs and memory (in bytes) reserved by all VMs this service is managing.
+    /// Used to compute accurate available-resource figures for the scheduler.
+    func reservedResources() -> (vcpus: Int, memoryBytes: Int64) {
+        var vcpus = 0
+        var memoryBytes: Int64 = 0
+        for config in vmConfigs.values {
+            vcpus += config.cpus?.bootVcpus ?? 0
+            memoryBytes += config.memory?.size ?? 0
+        }
+        return (vcpus, memoryBytes)
+    }
+
     // MARK: - Private Methods
 
     private func setupVMNetworking(vmId: String, networks: [NetConfig]) async throws {

--- a/agent/Sources/StratoAgent/HostResources.swift
+++ b/agent/Sources/StratoAgent/HostResources.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Probes the host machine for real CPU, memory, and disk capacity.
+///
+/// Used by the agent to report accurate resource availability to the control-plane
+/// scheduler instead of hardcoded mock values. All probes rely on Foundation APIs
+/// that are available on both macOS and Linux (swift-corelibs-foundation), so no
+/// platform-specific `/proc` parsing is required.
+enum HostResources {
+    /// Number of logical CPU cores currently available to the agent process.
+    static var logicalCoreCount: Int {
+        ProcessInfo.processInfo.activeProcessorCount
+    }
+
+    /// Total physical RAM on the host, in bytes.
+    static var physicalMemoryBytes: Int64 {
+        Int64(clamping: ProcessInfo.processInfo.physicalMemory)
+    }
+
+    /// Total and free bytes of the filesystem backing the given path.
+    ///
+    /// If `path` does not yet exist (e.g. the VM storage directory hasn't been
+    /// created), the nearest existing ancestor directory is queried instead, since
+    /// it resolves to the same filesystem. Returns `nil` if capacity cannot be read.
+    static func diskCapacity(forPath path: String) -> (total: Int64, free: Int64)? {
+        let fileManager = FileManager.default
+
+        // Resolve to the nearest existing ancestor so statfs has a real entry to inspect.
+        var probePath = path.isEmpty ? "/" : path
+        while !fileManager.fileExists(atPath: probePath) {
+            let parent = (probePath as NSString).deletingLastPathComponent
+            if parent.isEmpty || parent == probePath {
+                probePath = "/"
+                break
+            }
+            probePath = parent
+        }
+
+        guard let attributes = try? fileManager.attributesOfFileSystem(forPath: probePath),
+              let total = (attributes[.systemSize] as? NSNumber)?.int64Value,
+              let free = (attributes[.systemFreeSize] as? NSNumber)?.int64Value else {
+            return nil
+        }
+
+        return (total: total, free: free)
+    }
+}

--- a/agent/Sources/StratoAgent/QEMUService.swift
+++ b/agent/Sources/StratoAgent/QEMUService.swift
@@ -15,6 +15,13 @@ actor QEMUService: HypervisorService {
     private let qemuBinaryPath: String
     private let configuredFirmwarePath: String?
 
+    // Durable record of managed VMs, used to detect VMs orphaned by an agent restart.
+    private let manifestStore: VMManifestStore
+    /// VM IDs this agent was managing before the current process started. These are
+    /// not under active management (no QEMU re-adoption in Option A) and are reported
+    /// to operators so the control plane can reconcile them.
+    private(set) var orphanedVMIDs: Set<String> = []
+
     // HypervisorService protocol requirement
     public let hypervisorType: HypervisorType = .qemu
 
@@ -38,6 +45,22 @@ actor QEMUService: HypervisorService {
         self.vmStoragePath = vmStoragePath
         self.qemuBinaryPath = qemuBinaryPath
         self.configuredFirmwarePath = firmwarePath
+        self.manifestStore = VMManifestStore(
+            path: (vmStoragePath as NSString).appendingPathComponent("qemu-manifest.json"),
+            logger: logger
+        )
+
+        // Any VMs recorded in the manifest were managed by a previous incarnation of
+        // this agent. We do not re-adopt them (Option A), so record them as orphaned
+        // and warn — the control plane will mark them for attention via reconciliation.
+        let previousManifest = manifestStore.load()
+        if !previousManifest.isEmpty {
+            let ids = Set(previousManifest.keys)
+            orphanedVMIDs = ids
+            logger.warning("Found \(previousManifest.count) VM(s) managed before restart; their QEMU processes are now unmanaged", metadata: [
+                "vmIds": .string(ids.sorted().joined(separator: ","))
+            ])
+        }
 
         #if canImport(SwiftQEMU)
         #if os(Linux)
@@ -208,6 +231,7 @@ actor QEMUService: HypervisorService {
 
         activeVMs[vmId] = qemuManager
         vmConfigs[vmId] = effectiveConfig
+        persistManifest()
 
         logger.info("QEMU VM created successfully", metadata: ["vmId": .string(vmId)])
         #else
@@ -351,6 +375,7 @@ actor QEMUService: HypervisorService {
         // Clean up VM resources
         activeVMs.removeValue(forKey: vmId)
         vmConfigs.removeValue(forKey: vmId)
+        persistManifest()
         vmNetworkInfo.removeValue(forKey: vmId)
 
         // Clean up console socket
@@ -508,6 +533,28 @@ actor QEMUService: HypervisorService {
         return Array(activeVMs.keys)
         #else
         return Array(mockVMs.keys)
+        #endif
+    }
+
+    /// Sum of vCPUs and memory (in bytes) reserved by all VMs this service is managing.
+    /// Used to compute accurate available-resource figures for the scheduler.
+    func reservedResources() -> (vcpus: Int, memoryBytes: Int64) {
+        var vcpus = 0
+        var memoryBytes: Int64 = 0
+        #if canImport(SwiftQEMU)
+        for config in vmConfigs.values {
+            vcpus += config.cpus?.bootVcpus ?? 0
+            memoryBytes += config.memory?.size ?? 0
+        }
+        #endif
+        return (vcpus, memoryBytes)
+    }
+
+    /// Persists the current set of managed VMs to the on-disk manifest so they can be
+    /// detected as orphaned after an agent restart.
+    private func persistManifest() {
+        #if canImport(SwiftQEMU)
+        manifestStore.save(vmConfigs)
         #endif
     }
 

--- a/agent/Sources/StratoAgent/QEMUService.swift
+++ b/agent/Sources/StratoAgent/QEMUService.swift
@@ -17,10 +17,16 @@ actor QEMUService: HypervisorService {
 
     // Durable record of managed VMs, used to detect VMs orphaned by an agent restart.
     private let manifestStore: VMManifestStore
-    /// VM IDs this agent was managing before the current process started. These are
-    /// not under active management (no QEMU re-adoption in Option A) and are reported
-    /// to operators so the control plane can reconcile them.
-    private(set) var orphanedVMIDs: Set<String> = []
+    /// VMs this agent was managing before the current process started. They are not
+    /// under active management (no QEMU re-adoption in Option A), but their configs
+    /// are retained: the orphaned QEMU processes may still be running and consuming
+    /// CPU/memory, so their reservations must keep counting against host capacity
+    /// until the VM is deleted or re-created.
+    private var orphanedVMConfigs: [String: VmConfig] = [:]
+
+    var orphanedVMIDs: Set<String> {
+        Set(orphanedVMConfigs.keys)
+    }
 
     // HypervisorService protocol requirement
     public let hypervisorType: HypervisorType = .qemu
@@ -55,10 +61,9 @@ actor QEMUService: HypervisorService {
         // and warn — the control plane will mark them for attention via reconciliation.
         let previousManifest = manifestStore.load()
         if !previousManifest.isEmpty {
-            let ids = Set(previousManifest.keys)
-            orphanedVMIDs = ids
-            logger.warning("Found \(previousManifest.count) VM(s) managed before restart; their QEMU processes are now unmanaged", metadata: [
-                "vmIds": .string(ids.sorted().joined(separator: ","))
+            orphanedVMConfigs = previousManifest
+            logger.warning("Found \(previousManifest.count) VM(s) managed before restart; their QEMU processes are now unmanaged but their resources stay reserved", metadata: [
+                "vmIds": .string(previousManifest.keys.sorted().joined(separator: ","))
             ])
         }
 
@@ -231,6 +236,9 @@ actor QEMUService: HypervisorService {
 
         activeVMs[vmId] = qemuManager
         vmConfigs[vmId] = effectiveConfig
+        // A re-created VM is actively managed again; drop any orphan record so its
+        // resources are not double-counted.
+        orphanedVMConfigs.removeValue(forKey: vmId)
         persistManifest()
 
         logger.info("QEMU VM created successfully", metadata: ["vmId": .string(vmId)])
@@ -361,6 +369,17 @@ actor QEMUService: HypervisorService {
     func deleteVM(vmId: String) async throws {
         #if canImport(SwiftQEMU)
         guard let qemuManager = activeVMs[vmId] else {
+            // Deleting an orphaned VM releases its manifest entry and reservation so
+            // the control plane can remove the record. The unmanaged QEMU process
+            // (if still alive) cannot be stopped from here — that needs operator
+            // cleanup (or Option B re-adoption).
+            if orphanedVMConfigs.removeValue(forKey: vmId) != nil {
+                persistManifest()
+                logger.warning("Deleted orphaned VM from manifest; any surviving QEMU process must be cleaned up manually", metadata: [
+                    "vmId": .string(vmId)
+                ])
+                return
+            }
             throw QEMUServiceError.vmNotFound("VM \(vmId) not found")
         }
 
@@ -543,7 +562,9 @@ actor QEMUService: HypervisorService {
         #endif
     }
 
-    /// Sum of vCPUs and memory (in bytes) reserved by all VMs this service is managing.
+    /// Sum of vCPUs and memory (in bytes) reserved by all VMs this service is managing,
+    /// plus VMs orphaned by an agent restart — their QEMU processes may still be
+    /// running, so the scheduler must not hand their capacity to new placements.
     /// Used to compute accurate available-resource figures for the scheduler.
     func reservedResources() -> (vcpus: Int, memoryBytes: Int64) {
         var vcpus = 0
@@ -554,14 +575,19 @@ actor QEMUService: HypervisorService {
             memoryBytes += config.memory?.size ?? 0
         }
         #endif
+        for config in orphanedVMConfigs.values {
+            vcpus += config.cpus?.bootVcpus ?? 0
+            memoryBytes += config.memory?.size ?? 0
+        }
         return (vcpus, memoryBytes)
     }
 
     /// Persists the current set of managed VMs to the on-disk manifest so they can be
-    /// detected as orphaned after an agent restart.
+    /// detected as orphaned after an agent restart. Orphaned entries are carried over
+    /// (active configs win on ID collision) so a second restart still knows about them.
     private func persistManifest() {
         #if canImport(SwiftQEMU)
-        manifestStore.save(vmConfigs)
+        manifestStore.save(orphanedVMConfigs.merging(vmConfigs) { _, active in active })
         #endif
     }
 

--- a/agent/Sources/StratoAgent/QEMUService.swift
+++ b/agent/Sources/StratoAgent/QEMUService.swift
@@ -498,8 +498,12 @@ actor QEMUService: HypervisorService {
 
     func getVMStatus(vmId: String) async throws -> VMStatus {
         #if canImport(SwiftQEMU)
+        // Shut-down VMs stay in activeVMs until deleted, so an absent entry means
+        // this service does not manage the VM at all (e.g. lost on agent restart).
+        // Report that honestly instead of fabricating `.shutdown` — the control
+        // plane relies on the distinction to preserve a reconciled `.error` state.
         guard let qemuManager = activeVMs[vmId] else {
-            return .shutdown
+            throw HypervisorServiceError.vmNotFound(vmId)
         }
 
         do {
@@ -524,7 +528,10 @@ actor QEMUService: HypervisorService {
         }
         #else
         // Mock mode - return mock status
-        return mockVMs[vmId] != nil ? .running : .shutdown
+        guard mockVMs[vmId] != nil else {
+            throw HypervisorServiceError.vmNotFound(vmId)
+        }
+        return .running
         #endif
     }
 

--- a/agent/Sources/StratoAgent/VMManifestStore.swift
+++ b/agent/Sources/StratoAgent/VMManifestStore.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Logging
+import StratoShared
+
+/// Persists the set of VMs an agent is managing to disk so that, after an agent
+/// restart, the agent and the control plane can tell which VMs it previously owned.
+///
+/// Option A (reconcile-only): the agent does NOT re-adopt the running QEMU processes
+/// on restart — their QMP sockets use non-deterministic paths and SwiftQEMU has no
+/// attach API. Instead, previously-managed VMs are loaded and logged at startup, and
+/// because they are not placed back under management they are absent from the agent's
+/// heartbeat — which the control plane's reconciliation surfaces as `.error` for
+/// operator attention. Full re-adoption is the Option B follow-up and can build on
+/// this same on-disk manifest.
+struct VMManifestStore {
+    let path: String
+    let logger: Logger
+
+    /// Loads the previously-persisted VM manifest, or an empty map if none exists
+    /// or it cannot be read.
+    func load() -> [String: VmConfig] {
+        guard FileManager.default.fileExists(atPath: path) else { return [:] }
+        do {
+            let data = try Data(contentsOf: URL(fileURLWithPath: path))
+            return try JSONDecoder().decode([String: VmConfig].self, from: data)
+        } catch {
+            logger.error("Failed to read VM manifest at \(path): \(error)")
+            return [:]
+        }
+    }
+
+    /// Atomically writes the current manifest to disk.
+    func save(_ manifest: [String: VmConfig]) {
+        do {
+            let directory = (path as NSString).deletingLastPathComponent
+            if !directory.isEmpty {
+                try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
+            }
+            let data = try JSONEncoder().encode(manifest)
+            // Atomic write so a crash mid-write can't leave a truncated manifest.
+            try data.write(to: URL(fileURLWithPath: path), options: .atomic)
+        } catch {
+            logger.error("Failed to write VM manifest at \(path): \(error)")
+        }
+    }
+}

--- a/agent/Sources/StratoAgent/WebSocketClient.swift
+++ b/agent/Sources/StratoAgent/WebSocketClient.swift
@@ -47,7 +47,7 @@ final class LockedWebSocket: @unchecked Sendable {
 }
 
 actor WebSocketClient {
-    private let url: String
+    private var url: String
     private weak var agent: Agent?
     private let logger: Logger
     private let eventLoopGroup: MultiThreadedEventLoopGroup
@@ -77,6 +77,12 @@ actor WebSocketClient {
     func updateTLSConfiguration(_ tlsConfig: TLSConfiguration?) {
         self.tlsConfiguration = tlsConfig
         logger.info("TLS configuration updated")
+    }
+
+    /// Update the connection URL (for registration token rotation). Takes effect
+    /// on the next connect; the current connection is unaffected.
+    func updateURL(_ newURL: String) {
+        self.url = newURL
     }
 
     func connect() async throws {

--- a/agent/Sources/StratoAgent/WebSocketClient.swift
+++ b/agent/Sources/StratoAgent/WebSocketClient.swift
@@ -60,6 +60,10 @@ actor WebSocketClient {
     private var isConnected = false
     private var heartbeatTask: Task<Void, Never>?
 
+    // Distinguishes an operator-initiated disconnect (no reconnect) from an unexpected
+    // drop (triggers the agent's reconnection loop).
+    private var intentionalDisconnect = false
+
     init(url: String, agent: Agent, logger: Logger, tlsConfiguration: TLSConfiguration? = nil) {
         self.url = url
         self.agent = agent
@@ -77,6 +81,9 @@ actor WebSocketClient {
 
     func connect() async throws {
         logger.info("Attempting to connect to WebSocket server", metadata: ["url": .string(url)])
+
+        // A fresh connection attempt is, by definition, not an intentional disconnect.
+        intentionalDisconnect = false
 
         // Parse URL
         guard let parsedURL = URL(string: url) else {
@@ -114,12 +121,18 @@ actor WebSocketClient {
             let loggerRef = self.logger
             let agentRef = self.agent
 
-            // Create connection - this returns immediately, callback fires when connected
+            // Create connection - this returns immediately, callback fires when connected.
+            // Capture self weakly so the onClose handler can hop back to the actor without
+            // forming a self -> wsHolder -> ws -> onClose -> self retain cycle.
             WebSocket.connect(
                 to: url,
                 configuration: wsConfig,
                 on: eventLoop
-            ) { ws in
+            ) { [weak self] ws in
+                // Immutable, Sendable weak reference to this actor for use in the
+                // nested close handler (avoids capturing the mutable `self` binding).
+                let clientRef = self
+
                 // Store WebSocket in thread-safe box (still on EventLoop)
                 wsHolderRef.set(ws)
 
@@ -181,6 +194,9 @@ actor WebSocketClient {
                 ws.onClose.whenComplete { _ in
                     loggerRef.info("WebSocket connection closed")
                     wsHolderRef.set(nil)
+                    // Bridge the event-loop callback back onto the actor to update
+                    // connection state and trigger reconnection if this was unexpected.
+                    Task { await clientRef?.handleConnectionClosed() }
                 }
 
                 loggerRef.info("WebSocket connection established and ready")
@@ -209,6 +225,9 @@ actor WebSocketClient {
         }
 
         logger.info("Disconnecting from WebSocket server")
+
+        // Mark this close as intentional so the onClose handler does not reconnect.
+        intentionalDisconnect = true
 
         // Stop heartbeat
         heartbeatTask?.cancel()
@@ -255,6 +274,22 @@ actor WebSocketClient {
     }
 
     // MARK: - Private Methods
+
+    /// Invoked when the underlying WebSocket closes. Tears down connection state and,
+    /// unless the close was operator-initiated, asks the agent to begin reconnecting.
+    private func handleConnectionClosed() async {
+        isConnected = false
+        heartbeatTask?.cancel()
+        heartbeatTask = nil
+
+        if intentionalDisconnect {
+            logger.debug("WebSocket closed intentionally; not reconnecting")
+            return
+        }
+
+        logger.warning("WebSocket closed unexpectedly; requesting reconnection")
+        await agent?.handleConnectionLost()
+    }
 
     private func startHeartbeat() {
         heartbeatTask = Task {

--- a/agent/Sources/StratoAgentCore/WebSocketURLs.swift
+++ b/agent/Sources/StratoAgentCore/WebSocketURLs.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+public enum WebSocketURLs {
+    /// Returns `urlString` with the value of its `token` query parameter replaced,
+    /// or nil if the URL is unparseable or has no `token` parameter.
+    ///
+    /// Registration tokens are single-use: the control plane consumes the presented
+    /// token on connect and returns a rotated one in the registration response, which
+    /// must replace the token in the URL the reconnect loop dials.
+    public static func replacingTokenQueryParameter(in urlString: String, with token: String) -> String? {
+        guard var components = URLComponents(string: urlString),
+              var items = components.queryItems,
+              let index = items.firstIndex(where: { $0.name == "token" }) else {
+            return nil
+        }
+        items[index].value = token
+        components.queryItems = items
+        return components.string
+    }
+}

--- a/agent/Tests/StratoAgentTests/WebSocketURLsTests.swift
+++ b/agent/Tests/StratoAgentTests/WebSocketURLsTests.swift
@@ -1,0 +1,39 @@
+import Testing
+import Foundation
+@testable import StratoAgentCore
+
+@Suite("WebSocketURLs Tests")
+struct WebSocketURLsTests {
+
+    @Test("Replaces the token query parameter")
+    func replacesToken() {
+        let url = "ws://control-plane:8080/agent/ws?token=old-token&name=agent-1"
+        let result = WebSocketURLs.replacingTokenQueryParameter(in: url, with: "new-token")
+        #expect(result == "ws://control-plane:8080/agent/ws?token=new-token&name=agent-1")
+    }
+
+    @Test("Preserves other query parameters and their order")
+    func preservesOtherParameters() {
+        let url = "wss://cp.example.com/agent/ws?name=node-a&token=abc123"
+        let result = WebSocketURLs.replacingTokenQueryParameter(in: url, with: "xyz789")
+        #expect(result == "wss://cp.example.com/agent/ws?name=node-a&token=xyz789")
+    }
+
+    @Test("Returns nil when the URL has no token parameter")
+    func nilWithoutToken() {
+        let url = "wss://cp.example.com/agent/ws?name=node-a"
+        #expect(WebSocketURLs.replacingTokenQueryParameter(in: url, with: "xyz") == nil)
+    }
+
+    @Test("Returns nil when the URL has no query at all")
+    func nilWithoutQuery() {
+        #expect(WebSocketURLs.replacingTokenQueryParameter(in: "ws://cp:8080/agent/ws", with: "xyz") == nil)
+    }
+
+    @Test("Percent-encoded agent names survive the rewrite")
+    func percentEncodedNamePreserved() {
+        let url = "ws://cp:8080/agent/ws?token=old&name=node%20one"
+        let result = WebSocketURLs.replacingTokenQueryParameter(in: url, with: "new")
+        #expect(result == "ws://cp:8080/agent/ws?token=new&name=node%20one")
+    }
+}

--- a/control-plane/Sources/App/Controllers/AgentWebSocketController.swift
+++ b/control-plane/Sources/App/Controllers/AgentWebSocketController.swift
@@ -322,7 +322,7 @@ struct AgentWebSocketController: RouteCollection {
                 let message = try envelope.decode(as: AgentHeartbeatMessage.self)
                 Task {
                     do {
-                        try await req.agentService.updateAgentHeartbeat(message)
+                        try await req.agentService.updateAgentHeartbeat(message, fromAgentNamed: agentName)
                         self.sendSuccessResponse(ws: ws, requestId: message.requestId, message: "Heartbeat acknowledged")
                     } catch {
                         req.logger.error("Failed to update heartbeat: \(error)")

--- a/control-plane/Sources/App/Controllers/AgentWebSocketController.swift
+++ b/control-plane/Sources/App/Controllers/AgentWebSocketController.swift
@@ -175,8 +175,15 @@ struct AgentWebSocketController: RouteCollection {
                 ])
             }
 
-            // Clean up connection tracking
-            req.application.websocketManager.removeConnection(agentName: agentName)
+            // Only tear down agent state if this socket is still the agent's current
+            // connection — a delayed close from a connection the agent has already
+            // replaced (reconnect under the same name) must not remove its successor.
+            guard req.application.websocketManager.removeConnection(agentName: agentName, ifCurrent: ws) else {
+                req.logger.debug("Closed WebSocket was already superseded; skipping agent cleanup", metadata: [
+                    "agentName": .string(agentName)
+                ])
+                return
+            }
 
             // Mark agent as offline asynchronously
             Task {
@@ -486,8 +493,15 @@ struct AgentWebSocketController: RouteCollection {
                     ])
                 }
 
-                // Clean up connection tracking
-                req.application.websocketManager.removeConnection(agentName: agentName)
+                // Only tear down agent state if this socket is still the agent's current
+                // connection — a delayed close from a connection the agent has already
+                // replaced (reconnect under the same name) must not remove its successor.
+                guard req.application.websocketManager.removeConnection(agentName: agentName, ifCurrent: ws) else {
+                    req.logger.debug("Closed WebSocket was already superseded; skipping agent cleanup", metadata: [
+                        "agentName": .string(agentName)
+                    ])
+                    return
+                }
 
                 // Mark agent as offline asynchronously
                 Task {

--- a/control-plane/Sources/App/Controllers/AgentWebSocketController.swift
+++ b/control-plane/Sources/App/Controllers/AgentWebSocketController.swift
@@ -281,14 +281,35 @@ struct AgentWebSocketController: RouteCollection {
             switch envelope.type {
             case .agentRegister:
                 let message = try envelope.decode(as: AgentRegisterMessage.self)
+                let isTokenAuthenticated = req.query[String.self, at: "token"] != nil
                 Task {
                     do {
                         let agentUUID = try await req.agentService.registerAgent(message, agentName: agentName)
+
+                        // Rotate the single-use registration token: the one this
+                        // connection presented was consumed at validation, so without a
+                        // fresh token an automatic reconnect after an unexpected drop
+                        // would be rejected. Rotation failure is non-fatal — the agent
+                        // is registered either way, reconnect just needs a new token.
+                        var reconnectToken: String?
+                        if isTokenAuthenticated {
+                            do {
+                                // Generous expiry: the token sits unused until the
+                                // connection drops, which may be long after registration.
+                                let rotated = AgentRegistrationToken(agentName: agentName, expirationHours: 24 * 30)
+                                try await rotated.save(on: req.db)
+                                reconnectToken = rotated.token
+                            } catch {
+                                req.logger.error("Failed to rotate reconnect token for agent \(agentName): \(error)")
+                            }
+                        }
+
                         // Send registration response with the assigned UUID
                         let response = AgentRegisterResponseMessage(
                             requestId: message.requestId,
                             agentId: agentUUID.uuidString,
-                            name: agentName
+                            name: agentName,
+                            reconnectToken: reconnectToken
                         )
                         self.sendMessage(ws: ws, message: response)
                     } catch {

--- a/control-plane/Sources/App/Controllers/AgentWebSocketController.swift
+++ b/control-plane/Sources/App/Controllers/AgentWebSocketController.swift
@@ -321,10 +321,16 @@ struct AgentWebSocketController: RouteCollection {
                     }
                 }
 
-            case .success, .error, .statusUpdate:
-                // Handle responses from agents
+            case .success, .error:
+                // Correlated responses to control-plane-initiated requests
                 Task {
                     await req.agentService.handleAgentResponse(envelope)
+                }
+
+            case .statusUpdate:
+                // Unsolicited VM state change reported by the agent; persist it
+                Task {
+                    await req.agentService.applyStatusUpdate(envelope)
                 }
 
             case .consoleData:

--- a/control-plane/Sources/App/Controllers/AgentWebSocketController.swift
+++ b/control-plane/Sources/App/Controllers/AgentWebSocketController.swift
@@ -330,7 +330,7 @@ struct AgentWebSocketController: RouteCollection {
             case .statusUpdate:
                 // Unsolicited VM state change reported by the agent; persist it
                 Task {
-                    await req.agentService.applyStatusUpdate(envelope)
+                    await req.agentService.applyStatusUpdate(envelope, fromAgentNamed: agentName)
                 }
 
             case .consoleData:

--- a/control-plane/Sources/App/Controllers/VMController.swift
+++ b/control-plane/Sources/App/Controllers/VMController.swift
@@ -456,12 +456,15 @@ struct VMController: RouteCollection {
             throw Abort(.notFound)
         }
 
-        // Sync status with agent if VM exists there
-        if vm.hypervisorId != nil {
+        // Sync status with agent if VM exists there. Transitional states are owned by
+        // the dispatch path and confirmed via the agent's statusUpdate; a concurrent
+        // poll may still see the pre-operation state on the agent and must not
+        // overwrite the in-flight marker (which the stuck-VM sweep relies on).
+        if vm.hypervisorId != nil && !vm.status.isTransitional {
             do {
                 let actualStatus = try await req.agentService.getVMStatus(vmId: vm.id?.uuidString ?? "")
                 if actualStatus != vm.status {
-                    vm.status = actualStatus
+                    vm.setStatus(actualStatus)
                     try await vm.save(on: req.db)
                 }
             } catch {

--- a/control-plane/Sources/App/Controllers/VMController.swift
+++ b/control-plane/Sources/App/Controllers/VMController.swift
@@ -487,6 +487,7 @@ struct VMController: RouteCollection {
 
         // Decide boot-vs-resume before we overwrite the status with a transitional one.
         let bootFresh = vm.shouldBootOnStart
+        let previousStatus = vm.status
 
         do {
             // Mark the operation in flight before dispatching, so a crash or lost
@@ -509,11 +510,21 @@ struct VMController: RouteCollection {
         } catch {
             req.logger.error("Failed to start VM: \(error)", metadata: ["vm_id": .string(vm.id?.uuidString ?? "")])
 
-            // Sync status with agent if reachable; otherwise leave it `.starting` for
-            // the reconciliation sweep to resolve.
-            if let actualStatus = try? await req.agentService.getVMStatus(vmId: vm.id?.uuidString ?? "") {
-                vm.setStatus(actualStatus)
+            switch error {
+            case AgentServiceError.vmNotMapped, AgentServiceError.agentNotFound:
+                // Thrown before anything was sent to an agent (e.g. the VM was never
+                // assigned one), and a status sync would fail the same way — restore
+                // the prior state instead of leaving a phantom `.starting` for the
+                // sweep to escalate to `.error`.
+                vm.setStatus(previousStatus)
                 try await vm.save(on: req.db)
+            default:
+                // Sync status with agent if reachable; otherwise leave it `.starting`
+                // for the reconciliation sweep to resolve.
+                if let actualStatus = try? await req.agentService.getVMStatus(vmId: vm.id?.uuidString ?? "") {
+                    vm.setStatus(actualStatus)
+                    try await vm.save(on: req.db)
+                }
             }
 
             throw Abort(.internalServerError, reason: "Failed to start VM: \(error.localizedDescription)")
@@ -535,6 +546,8 @@ struct VMController: RouteCollection {
             throw Abort(.badRequest, reason: "VM cannot be stopped in current state: \(vm.status.rawValue)")
         }
 
+        let previousStatus = vm.status
+
         do {
             // Mark the operation in flight; the agent confirms `.shutdown` via a
             // statusUpdate once the guest powers off, and the sweep catches stuck stops.
@@ -548,11 +561,20 @@ struct VMController: RouteCollection {
         } catch {
             req.logger.error("Failed to stop VM: \(error)", metadata: ["vm_id": .string(vm.id?.uuidString ?? "")])
 
-            // Sync status with agent if reachable; otherwise leave it `.stopping` for
-            // the reconciliation sweep to resolve.
-            if let actualStatus = try? await req.agentService.getVMStatus(vmId: vm.id?.uuidString ?? "") {
-                vm.setStatus(actualStatus)
+            switch error {
+            case AgentServiceError.vmNotMapped, AgentServiceError.agentNotFound:
+                // Thrown before anything was sent to an agent, and a status sync
+                // would fail the same way — restore the prior state instead of
+                // leaving a phantom `.stopping` for the sweep to escalate to `.error`.
+                vm.setStatus(previousStatus)
                 try await vm.save(on: req.db)
+            default:
+                // Sync status with agent if reachable; otherwise leave it `.stopping`
+                // for the reconciliation sweep to resolve.
+                if let actualStatus = try? await req.agentService.getVMStatus(vmId: vm.id?.uuidString ?? "") {
+                    vm.setStatus(actualStatus)
+                    try await vm.save(on: req.db)
+                }
             }
 
             throw Abort(.internalServerError, reason: "Failed to stop VM: \(error.localizedDescription)")

--- a/control-plane/Sources/App/Controllers/VMController.swift
+++ b/control-plane/Sources/App/Controllers/VMController.swift
@@ -485,28 +485,36 @@ struct VMController: RouteCollection {
             throw Abort(.badRequest, reason: "VM cannot be started in current state: \(vm.status.rawValue)")
         }
 
+        // Decide boot-vs-resume before we overwrite the status with a transitional one.
+        let bootFresh = vm.shouldBootOnStart
+
         do {
-            if vm.status == .created || vm.status == .shutdown {
-                // Boot the VM (fresh start or restart after shutdown)
+            // Mark the operation in flight before dispatching, so a crash or lost
+            // confirmation leaves the VM detectably `.starting` (the sweep will catch
+            // it) rather than silently appearing stopped. The agent confirms the
+            // terminal `.running` state via a statusUpdate once the VM is up.
+            vm.setStatus(.starting)
+            try await vm.save(on: req.db)
+
+            if bootFresh {
+                // Boot the VM (fresh start or restart after shutdown/error)
                 try await req.agentService.performVMOperation(.vmBoot, vmId: vm.id?.uuidString ?? "")
             } else {
                 // Resume from paused state
                 try await req.agentService.performVMOperation(.vmResume, vmId: vm.id?.uuidString ?? "")
             }
 
-            // Update VM status
-            vm.status = VMStatus.running
-            try await vm.save(on: req.db)
-
-            req.logger.info("VM started successfully", metadata: ["vm_id": .string(vm.id?.uuidString ?? "")])
+            req.logger.info("VM start requested", metadata: ["vm_id": .string(vm.id?.uuidString ?? "")])
 
         } catch {
             req.logger.error("Failed to start VM: \(error)", metadata: ["vm_id": .string(vm.id?.uuidString ?? "")])
 
-            // Sync status with agent
-            let actualStatus = try await req.agentService.getVMStatus(vmId: vm.id?.uuidString ?? "")
-            vm.status = actualStatus
-            try await vm.save(on: req.db)
+            // Sync status with agent if reachable; otherwise leave it `.starting` for
+            // the reconciliation sweep to resolve.
+            if let actualStatus = try? await req.agentService.getVMStatus(vmId: vm.id?.uuidString ?? "") {
+                vm.setStatus(actualStatus)
+                try await vm.save(on: req.db)
+            }
 
             throw Abort(.internalServerError, reason: "Failed to start VM: \(error.localizedDescription)")
         }
@@ -528,21 +536,24 @@ struct VMController: RouteCollection {
         }
 
         do {
-            try await req.agentService.performVMOperation(.vmShutdown, vmId: vm.id?.uuidString ?? "")
-
-            // Update VM status
-            vm.status = VMStatus.shutdown
+            // Mark the operation in flight; the agent confirms `.shutdown` via a
+            // statusUpdate once the guest powers off, and the sweep catches stuck stops.
+            vm.setStatus(.stopping)
             try await vm.save(on: req.db)
 
-            req.logger.info("VM stopped successfully", metadata: ["vm_id": .string(vm.id?.uuidString ?? "")])
+            try await req.agentService.performVMOperation(.vmShutdown, vmId: vm.id?.uuidString ?? "")
+
+            req.logger.info("VM stop requested", metadata: ["vm_id": .string(vm.id?.uuidString ?? "")])
 
         } catch {
             req.logger.error("Failed to stop VM: \(error)", metadata: ["vm_id": .string(vm.id?.uuidString ?? "")])
 
-            // Sync status with agent
-            let actualStatus = try await req.agentService.getVMStatus(vmId: vm.id?.uuidString ?? "")
-            vm.status = actualStatus
-            try await vm.save(on: req.db)
+            // Sync status with agent if reachable; otherwise leave it `.stopping` for
+            // the reconciliation sweep to resolve.
+            if let actualStatus = try? await req.agentService.getVMStatus(vmId: vm.id?.uuidString ?? "") {
+                vm.setStatus(actualStatus)
+                try await vm.save(on: req.db)
+            }
 
             throw Abort(.internalServerError, reason: "Failed to stop VM: \(error.localizedDescription)")
         }

--- a/control-plane/Sources/App/Migrations/AddStatusChangedAtToVM.swift
+++ b/control-plane/Sources/App/Migrations/AddStatusChangedAtToVM.swift
@@ -1,0 +1,18 @@
+import Fluent
+
+struct AddStatusChangedAtToVM: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        // Tracks when a VM's status last changed, so the reconciliation sweep can
+        // detect VMs stuck in a transitional state. Nullable: existing rows are in
+        // terminal states and are ignored by the sweep until they next transition.
+        try await database.schema("vms")
+            .field("status_changed_at", .datetime)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("vms")
+            .deleteField("status_changed_at")
+            .update()
+    }
+}

--- a/control-plane/Sources/App/Models/vm.swift
+++ b/control-plane/Sources/App/Models/vm.swift
@@ -25,6 +25,11 @@ final class VM: Model, @unchecked Sendable {
     @OptionalField(key: "hypervisor_id")
     var hypervisorId: String?
 
+    // When `status` last changed. Used by the reconciliation sweep to detect VMs
+    // stuck in a transitional state past a timeout.
+    @OptionalField(key: "status_changed_at")
+    var statusChangedAt: Date?
+
     @Enum(key: "hypervisor_type")
     var hypervisorType: HypervisorType
 
@@ -213,11 +218,25 @@ extension VM {
     }
 
     var canStart: Bool {
-        return status == .created || status == .shutdown
+        // `.error` is included so an operator can recover a VM whose state could not
+        // be confirmed (e.g. a lost or timed-out start).
+        return status == .created || status == .shutdown || status == .error
     }
 
     var canStop: Bool {
         return status == .running || status == .paused
+    }
+
+    /// True when a fresh boot is the right action (as opposed to resuming from pause).
+    var shouldBootOnStart: Bool {
+        return status == .created || status == .shutdown || status == .error
+    }
+
+    /// Updates the VM status and stamps the change time for the reconciliation sweep.
+    /// Does not persist — call `save(on:)` afterwards.
+    func setStatus(_ newStatus: VMStatus, at date: Date = Date()) {
+        status = newStatus
+        statusChangedAt = date
     }
 
     var canPause: Bool {

--- a/control-plane/Sources/App/Services/AgentService.swift
+++ b/control-plane/Sources/App/Services/AgentService.swift
@@ -729,6 +729,27 @@ actor AgentService {
 
                 guard vm.status != update.status else { return }
 
+                // A transitional state means a control-plane-initiated operation is in
+                // flight. Only the confirmation that completes that transition (or an
+                // error) may land; anything else is a delayed update from an operation
+                // that predates the transition — the controller guards (canStart/canStop/
+                // canPause) make any other concurrent operation impossible — and applying
+                // it would mask the in-flight one (e.g. a late `Paused` overwriting
+                // `.stopping`, hiding a lost stop from the sweep).
+                if vm.status.isTransitional {
+                    let expected: Set<VMStatus> = vm.status == .starting
+                        ? [.running, .error]
+                        : [.shutdown, .error]
+                    guard expected.contains(update.status) else {
+                        app.logger.warning("Ignoring stale agent status update during in-flight operation", metadata: [
+                            "vmId": .string(update.vmId),
+                            "current": .string(vm.status.rawValue),
+                            "reported": .string(update.status.rawValue)
+                        ])
+                        return
+                    }
+                }
+
                 let previous = vm.status
                 vm.setStatus(update.status)
                 try await vm.save(on: app.db)

--- a/control-plane/Sources/App/Services/AgentService.swift
+++ b/control-plane/Sources/App/Services/AgentService.swift
@@ -235,9 +235,21 @@ actor AgentService {
         }
     }
 
-    func updateAgentHeartbeat(_ message: AgentHeartbeatMessage) async throws {
+    /// `agentName` identifies the authenticated connection the heartbeat arrived on;
+    /// the claimed `agentId` must belong to it, so one agent cannot drive another
+    /// agent's resource tracking or VM reconciliation.
+    func updateAgentHeartbeat(_ message: AgentHeartbeatMessage, fromAgentNamed agentName: String) async throws {
         guard var agentInfo = agents[message.agentId] else {
             app.logger.warning("Received heartbeat from unknown agent", metadata: ["agentId": .string(message.agentId)])
+            return
+        }
+
+        guard agentInfo.name == agentName else {
+            app.logger.warning("Heartbeat claims an agentId not owned by the authenticated connection; ignoring", metadata: [
+                "claimedAgentId": .string(message.agentId),
+                "claimedAgentName": .string(agentInfo.name),
+                "connectionAgentName": .string(agentName)
+            ])
             return
         }
 

--- a/control-plane/Sources/App/Services/AgentService.swift
+++ b/control-plane/Sources/App/Services/AgentService.swift
@@ -46,8 +46,15 @@ actor AgentService {
     private let app: Application
     private var agents: [String: AgentInfo] = [:]
     private var vmToAgentMapping: [String: String] = [:] // VM ID -> Agent ID
-    private var pendingRequests: [String: CheckedContinuation<AgentServiceResponse, Error>] = [:]
+    private var pendingRequests: [String: PendingRequest] = [:]
     private var heartbeatTask: Task<Void, Never>?
+
+    /// A request awaiting a response from a specific agent.
+    /// Tracking the agent lets us fail all of an agent's in-flight requests when it disconnects.
+    private struct PendingRequest {
+        let agentId: String
+        let continuation: CheckedContinuation<AgentServiceResponse, Error>
+    }
 
     init(app: Application) {
         self.app = app
@@ -153,6 +160,9 @@ actor AgentService {
         // Get agent name for WebSocket cleanup
         let agentName = agents[agentId]?.name
 
+        // Fail any in-flight requests waiting on this agent before we drop it
+        failPendingRequests(for: agentId)
+
         // Remove from in-memory tracking
         agents.removeValue(forKey: agentId)
         if let name = agentName {
@@ -178,6 +188,9 @@ actor AgentService {
             return
         }
 
+        // Fail any in-flight requests waiting on this agent before we drop it
+        failPendingRequests(for: agentId)
+
         // Remove from in-memory tracking
         agents.removeValue(forKey: agentId)
         app.websocketManager.removeConnection(agentName: agentName)
@@ -200,6 +213,9 @@ actor AgentService {
             app.logger.debug("Cannot remove agent: not found by name", metadata: ["agentName": .string(agentName)])
             return
         }
+
+        // Fail any in-flight requests waiting on this agent before we drop it
+        failPendingRequests(for: agentId)
 
         // Mark agent as offline in memory
         agents.removeValue(forKey: agentId)
@@ -249,7 +265,69 @@ actor AgentService {
             }
         }
 
+        // Reconcile the VMs the agent reports against what the database expects.
+        Task {
+            await self.reconcileVMs(forAgentId: message.agentId, reportedVMs: message.runningVMs)
+        }
+
         app.logger.debug("Agent heartbeat updated", metadata: ["agentId": .string(message.agentId)])
+    }
+
+    /// Reconciles an agent's reported set of managed VMs against the database.
+    ///
+    /// An agent's heartbeat lists every VM it is managing (running, paused, or
+    /// shut-down-but-not-deleted). If the database believes a VM lives on this agent
+    /// but the agent no longer reports it — e.g. the agent crashed and lost the VM,
+    /// or the process died — the database's view is stale and we mark the VM `.error`
+    /// so it surfaces for operator attention instead of appearing healthy.
+    private func reconcileVMs(forAgentId agentId: String, reportedVMs: [String]) async {
+        let db = app.db
+        let managed = Set(reportedVMs)
+
+        do {
+            let dbVMs = try await VM.query(on: db)
+                .filter(\.$hypervisorId == agentId)
+                .all()
+
+            var divergent = 0
+            for vm in dbVMs {
+                guard let vmId = vm.id?.uuidString else { continue }
+
+                // Only established states are safe to reconcile on absence:
+                //  - `.created` may still be mid-creation (image download / first boot)
+                //  - transitional and `.error`/`.unknown` states are handled by the sweep
+                // so an absent VM in those states is expected and left alone.
+                let reconcilable = (vm.status == .running || vm.status == .paused)
+                guard reconcilable, !managed.contains(vmId) else { continue }
+
+                let previous = vm.status
+                vm.setStatus(.error)
+                try await vm.save(on: db)
+                divergent += 1
+
+                app.logger.warning("VM missing from agent heartbeat; marking as error", metadata: [
+                    "vmId": .string(vmId),
+                    "agentId": .string(agentId),
+                    "previousStatus": .string(previous.rawValue)
+                ])
+            }
+
+            // Orphans: VMs the agent reports that the database does not map to it.
+            let knownIds = Set(dbVMs.compactMap { $0.id?.uuidString })
+            let orphans = managed.subtracting(knownIds)
+            if !orphans.isEmpty {
+                app.logger.warning("Agent reports VMs unknown to control plane", metadata: [
+                    "agentId": .string(agentId),
+                    "orphanVMs": .string(orphans.sorted().joined(separator: ","))
+                ])
+            }
+
+            if divergent > 0 {
+                app.logger.info("Reconciliation marked \(divergent) VM(s) as error", metadata: ["agentId": .string(agentId)])
+            }
+        } catch {
+            app.logger.error("VM reconciliation failed for agent \(agentId): \(error)")
+        }
     }
     
     // MARK: - Heartbeat Monitoring
@@ -260,9 +338,12 @@ actor AgentService {
                 do {
                     // Sleep for 30 seconds
                     try await Task.sleep(for: .seconds(30))
-                    
+
                     // Check for stale agents
                     await checkStaleAgents()
+
+                    // Move VMs stuck in a transitional state to error
+                    await sweepStuckTransitionalVMs()
                 } catch {
                     if !Task.isCancelled {
                         app.logger.error("Error in heartbeat monitoring task: \(error)")
@@ -287,6 +368,9 @@ actor AgentService {
             app.logger.info("Found \(staleAgents.count) stale agents, marking as offline")
 
             for agentId in staleAgents {
+                // Fail any in-flight requests waiting on this agent before we drop it
+                failPendingRequests(for: agentId)
+
                 // Remove from memory
                 agents.removeValue(forKey: agentId)
 
@@ -304,6 +388,41 @@ actor AgentService {
                     }
                 }
             }
+        }
+    }
+
+    /// Moves VMs that have been stuck in a transitional state (.starting/.stopping)
+    /// longer than the timeout to `.error`. This catches operations whose terminal
+    /// confirmation never arrived — e.g. the agent crashed mid-boot, or the
+    /// statusUpdate message was lost.
+    private func sweepStuckTransitionalVMs() async {
+        let db = app.db
+        let timeout: TimeInterval = 120 // a VM may legitimately be transitional this long
+        let now = Date()
+
+        do {
+            let transitional = try await VM.query(on: db)
+                .filter(\.$status ~~ [.starting, .stopping])
+                .all()
+
+            for vm in transitional {
+                // Fall back to updatedAt, then now, if the timestamp is somehow missing
+                // (a missing timestamp yields age 0 and is left for the next sweep).
+                let changedAt = vm.statusChangedAt ?? vm.updatedAt ?? now
+                guard now.timeIntervalSince(changedAt) > timeout else { continue }
+
+                let previous = vm.status
+                vm.setStatus(.error)
+                try await vm.save(on: db)
+
+                app.logger.warning("VM stuck in transitional state past timeout; marking as error", metadata: [
+                    "vmId": .string(vm.id?.uuidString ?? ""),
+                    "stuckStatus": .string(previous.rawValue),
+                    "timeoutSeconds": .string("\(Int(timeout))")
+                ])
+            }
+        } catch {
+            app.logger.error("Stuck-VM sweep failed: \(error)")
         }
     }
 
@@ -489,7 +608,7 @@ actor AgentService {
             Task {
                 do {
                     // Store continuation for response handling
-                    self.storePendingRequest(message.requestId, continuation: continuation)
+                    self.storePendingRequest(message.requestId, agentId: agentId, continuation: continuation)
 
                     // Send message
                     try await self.sendMessageToAgent(message, agentId: agentId)
@@ -507,12 +626,12 @@ actor AgentService {
         }
     }
 
-    private func storePendingRequest(_ requestId: String, continuation: CheckedContinuation<AgentServiceResponse, Error>) {
-        pendingRequests[requestId] = continuation
+    private func storePendingRequest(_ requestId: String, agentId: String, continuation: CheckedContinuation<AgentServiceResponse, Error>) {
+        pendingRequests[requestId] = PendingRequest(agentId: agentId, continuation: continuation)
     }
 
     private func removePendingRequest(_ requestId: String) -> CheckedContinuation<AgentServiceResponse, Error>? {
-        return pendingRequests.removeValue(forKey: requestId)
+        return pendingRequests.removeValue(forKey: requestId)?.continuation
     }
 
     private func timeoutRequest(_ requestId: String) {
@@ -521,11 +640,46 @@ actor AgentService {
         }
     }
 
+    /// Fail all in-flight requests targeting an agent that has gone away, so callers
+    /// get a prompt error instead of waiting for the per-request timeout.
+    private func failPendingRequests(for agentId: String, reason: AgentServiceError = .connectionLost) {
+        let affected = pendingRequests.filter { $0.value.agentId == agentId }
+        guard !affected.isEmpty else { return }
+
+        for (requestId, request) in affected {
+            pendingRequests.removeValue(forKey: requestId)
+            request.continuation.resume(throwing: reason)
+        }
+
+        app.logger.info("Failed \(affected.count) in-flight request(s) for disconnected agent", metadata: [
+            "agentId": .string(agentId)
+        ])
+    }
+
     // MARK: - Response Handling
 
     func handleAgentResponse(_ envelope: MessageEnvelope) {
         Task {
-            guard let continuation = self.removePendingRequest(envelope.payload.base64EncodedString()) else {
+            // Extract the original request's ID from the typed payload so we can
+            // correlate the response with the continuation that is waiting for it.
+            let requestId: String
+            do {
+                switch envelope.type {
+                case .success:
+                    requestId = try envelope.decode(as: SuccessMessage.self).requestId
+                case .error:
+                    requestId = try envelope.decode(as: ErrorMessage.self).requestId
+                default:
+                    // Other message types (e.g. unsolicited statusUpdate) are not
+                    // request/response correlated and are handled elsewhere.
+                    return
+                }
+            } catch {
+                app.logger.error("Failed to decode agent response envelope: \(error)")
+                return
+            }
+
+            guard let continuation = self.removePendingRequest(requestId) else {
                 return
             }
 
@@ -542,6 +696,47 @@ actor AgentService {
                 }
             } catch {
                 continuation.resume(throwing: error)
+            }
+        }
+    }
+
+    /// Applies an unsolicited VM status update reported by an agent to the database.
+    /// This is how transitional states (.starting/.stopping) get confirmed into their
+    /// terminal states (.running/.shutdown/.paused) once the agent completes the work.
+    func applyStatusUpdate(_ envelope: MessageEnvelope) {
+        Task {
+            let update: StatusUpdateMessage
+            do {
+                update = try envelope.decode(as: StatusUpdateMessage.self)
+            } catch {
+                app.logger.error("Failed to decode status update from agent: \(error)")
+                return
+            }
+
+            guard let vmUUID = UUID(uuidString: update.vmId) else {
+                app.logger.warning("Status update referenced an invalid VM id", metadata: ["vmId": .string(update.vmId)])
+                return
+            }
+
+            do {
+                guard let vm = try await VM.find(vmUUID, on: app.db) else {
+                    app.logger.warning("Status update for unknown VM", metadata: ["vmId": .string(update.vmId)])
+                    return
+                }
+
+                guard vm.status != update.status else { return }
+
+                let previous = vm.status
+                vm.setStatus(update.status)
+                try await vm.save(on: app.db)
+
+                app.logger.info("Applied agent status update", metadata: [
+                    "vmId": .string(update.vmId),
+                    "from": .string(previous.rawValue),
+                    "to": .string(update.status.rawValue)
+                ])
+            } catch {
+                app.logger.error("Failed to apply status update for VM \(update.vmId): \(error)")
             }
         }
     }
@@ -580,6 +775,7 @@ enum AgentServiceError: Error, LocalizedError, Sendable {
     case agentNotFound(String)
     case vmNotMapped(String)
     case requestTimeout
+    case connectionLost
     case invalidResponse(String)
 
     var errorDescription: String? {
@@ -592,6 +788,8 @@ enum AgentServiceError: Error, LocalizedError, Sendable {
             return "VM not mapped to any agent: \(vmId)"
         case .requestTimeout:
             return "Request to agent timed out"
+        case .connectionLost:
+            return "Connection to agent was lost before a response was received"
         case .invalidResponse(let message):
             return "Invalid response from agent: \(message)"
         }

--- a/control-plane/Sources/App/Services/AgentService.swift
+++ b/control-plane/Sources/App/Services/AgentService.swift
@@ -297,7 +297,10 @@ actor AgentService {
                 //  - `.created` may still be mid-creation (image download / first boot)
                 //  - transitional and `.error`/`.unknown` states are handled by the sweep
                 // so an absent VM in those states is expected and left alone.
-                let reconcilable = (vm.status == .running || vm.status == .paused)
+                // `.shutdown` counts as established: agents keep shut-down-but-not-deleted
+                // VMs in their managed set, so one missing from the heartbeat was lost
+                // (e.g. agent restart) and a later start would fail with vmNotFound.
+                let reconcilable = (vm.status == .running || vm.status == .paused || vm.status == .shutdown)
                 guard reconcilable, !managed.contains(vmId) else { continue }
 
                 let previous = vm.status

--- a/control-plane/Sources/App/Services/AgentService.swift
+++ b/control-plane/Sources/App/Services/AgentService.swift
@@ -706,7 +706,9 @@ actor AgentService {
     /// Applies an unsolicited VM status update reported by an agent to the database.
     /// This is how transitional states (.starting/.stopping) get confirmed into their
     /// terminal states (.running/.shutdown/.paused) once the agent completes the work.
-    func applyStatusUpdate(_ envelope: MessageEnvelope) {
+    /// `agentName` identifies the authenticated connection the update arrived on, so
+    /// an agent can only mutate VMs the database actually maps to it.
+    func applyStatusUpdate(_ envelope: MessageEnvelope, fromAgentNamed agentName: String) {
         Task {
             let update: StatusUpdateMessage
             do {
@@ -721,9 +723,27 @@ actor AgentService {
                 return
             }
 
+            guard let senderAgentId = self.findAgentIdByName(agentName) else {
+                app.logger.warning("Status update from unregistered agent; ignoring", metadata: [
+                    "vmId": .string(update.vmId),
+                    "agentName": .string(agentName)
+                ])
+                return
+            }
+
             do {
                 guard let vm = try await VM.find(vmUUID, on: app.db) else {
                     app.logger.warning("Status update for unknown VM", metadata: ["vmId": .string(update.vmId)])
+                    return
+                }
+
+                guard vm.hypervisorId == senderAgentId else {
+                    app.logger.warning("Status update from agent that does not own the VM; ignoring", metadata: [
+                        "vmId": .string(update.vmId),
+                        "agentName": .string(agentName),
+                        "senderAgentId": .string(senderAgentId),
+                        "owningAgentId": .string(vm.hypervisorId ?? "none")
+                    ])
                     return
                 }
 

--- a/control-plane/Sources/App/Services/AgentService.swift
+++ b/control-plane/Sources/App/Services/AgentService.swift
@@ -34,6 +34,18 @@ final class WebSocketManager: @unchecked Sendable {
         }
     }
 
+    /// Remove the connection for an agent only if the stored socket is the given
+    /// instance. Used by close handlers so a delayed close from a replaced
+    /// connection cannot tear down its successor (e.g. after an agent reconnects
+    /// under the same name). Returns true when the connection was removed.
+    func removeConnection(agentName: String, ifCurrent websocket: WebSocket) -> Bool {
+        lock.withLock {
+            guard connections[agentName] === websocket else { return false }
+            connections.removeValue(forKey: agentName)
+            return true
+        }
+    }
+
     /// Get all agent names (for diagnostics)
     func getAllAgentNames() -> [String] {
         lock.withLock {

--- a/control-plane/Sources/App/configure.swift
+++ b/control-plane/Sources/App/configure.swift
@@ -109,6 +109,10 @@ public func configure(_ app: Application) async throws {
     app.migrations.add(AddHypervisorTypeToVM())
     app.migrations.add(AddHypervisorTypeToAgent())
 
+    // VM state reconciliation: must run before any data migration that loads the VM
+    // model (e.g. MigrateVMDisksToVolumes), since the model now selects this column.
+    app.migrations.add(AddStatusChangedAtToVM())
+
     // App settings migration (for signing keys, etc.)
     app.migrations.add(CreateAppSetting())
 

--- a/control-plane/web/src/components/vms/vm-actions.tsx
+++ b/control-plane/web/src/components/vms/vm-actions.tsx
@@ -75,7 +75,12 @@ export function VMActions({ vm, onActionComplete }: VMActionsProps) {
     }
   };
 
-  const canStart = vm.status === "Shutdown" || vm.status === "Created";
+  // Mirrors the backend's VM.canStart: `Error` is startable so an operator can
+  // recover a VM whose state could not be confirmed (e.g. a lost start).
+  const canStart =
+    vm.status === "Shutdown" ||
+    vm.status === "Created" ||
+    vm.status === "Error";
   const canStop = vm.status === "Running" || vm.status === "Paused";
   const canPause = vm.status === "Running";
   const canResume = vm.status === "Paused";

--- a/control-plane/web/src/components/vms/vm-status-badge.tsx
+++ b/control-plane/web/src/components/vms/vm-status-badge.tsx
@@ -21,10 +21,27 @@ const statusConfig: Record<
     label: "Created",
     className: "bg-blue-500/20 text-blue-400 border-blue-500/30",
   },
+  Starting: {
+    label: "Starting",
+    className:
+      "bg-green-500/20 text-green-400 border-green-500/30 animate-pulse",
+  },
+  Stopping: {
+    label: "Stopping",
+    className: "bg-red-500/20 text-red-400 border-red-500/30 animate-pulse",
+  },
+  Error: {
+    label: "Error",
+    className: "bg-red-500/20 text-red-400 border-red-500/30",
+  },
+  Unknown: {
+    label: "Unknown",
+    className: "bg-gray-500/20 text-gray-400 border-gray-500/30",
+  },
 };
 
 export function VMStatusBadge({ status }: { status: VMStatus }) {
-  const config = statusConfig[status] || statusConfig.Created;
+  const config = statusConfig[status] || statusConfig.Unknown;
 
   return (
     <Badge variant="outline" className={config.className}>

--- a/control-plane/web/src/types/api.ts
+++ b/control-plane/web/src/types/api.ts
@@ -10,7 +10,15 @@ export interface User {
   isSystemAdmin: boolean;
 }
 
-export type VMStatus = "Running" | "Shutdown" | "Paused" | "Created";
+export type VMStatus =
+  | "Running"
+  | "Shutdown"
+  | "Paused"
+  | "Created"
+  | "Starting"
+  | "Stopping"
+  | "Error"
+  | "Unknown";
 
 export interface VM {
   id: string;

--- a/shared/Sources/StratoShared/VMModels.swift
+++ b/shared/Sources/StratoShared/VMModels.swift
@@ -7,6 +7,34 @@ public enum VMStatus: String, Codable, CaseIterable, Sendable {
     case running = "Running"
     case shutdown = "Shutdown"
     case paused = "Paused"
+
+    // Transitional states: a control-plane-initiated operation is in flight and the
+    // agent has not yet confirmed the terminal state. A reconciliation sweep moves
+    // VMs stuck in these states to `.error` after a timeout.
+    case starting = "Starting"
+    case stopping = "Stopping"
+
+    // Diagnostic states set by reconciliation, never by a normal operation.
+    case error = "Error"      // operation failed, timed out, or the VM vanished from its agent
+    case unknown = "Unknown"  // the VM's true state could not be determined
+
+    /// True while a requested operation is in flight and not yet confirmed by the agent.
+    public var isTransitional: Bool {
+        switch self {
+        case .starting, .stopping:
+            return true
+        case .created, .running, .shutdown, .paused, .error, .unknown:
+            return false
+        }
+    }
+
+    /// Tolerant decoding: an unrecognized status string (e.g. from a control plane or
+    /// agent running a different protocol version) decodes to `.unknown` instead of
+    /// throwing, so version skew cannot crash message handling.
+    public init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = VMStatus(rawValue: raw) ?? .unknown
+    }
 }
 
 public enum ConsoleMode: String, Codable, CaseIterable, Sendable {

--- a/shared/Sources/StratoShared/WebSocketProtocol.swift
+++ b/shared/Sources/StratoShared/WebSocketProtocol.swift
@@ -154,16 +154,25 @@ public struct AgentRegisterResponseMessage: WebSocketMessage {
     public let agentId: String  // The database UUID assigned to this agent
     public let name: String     // The human-readable name
 
+    /// Fresh single-use token for the agent's next (re)connection. Registration
+    /// tokens are consumed on connect, so the control plane rotates them here —
+    /// otherwise the agent's automatic reconnect after an unexpected drop would
+    /// present an already-used token and be rejected. Nil for mTLS-authenticated
+    /// connections (and from control planes that predate rotation).
+    public let reconnectToken: String?
+
     public init(
         requestId: String,
         timestamp: Date = Date(),
         agentId: String,
-        name: String
+        name: String,
+        reconnectToken: String? = nil
     ) {
         self.requestId = requestId
         self.timestamp = timestamp
         self.agentId = agentId
         self.name = name
+        self.reconnectToken = reconnectToken
     }
 }
 


### PR DESCRIPTION
## Summary

Closes four gaps in the control plane↔agent contract surfaced by an architecture audit. Each phase is independently motivated; together they make the distributed state honest and the connection self-healing.

### Phase 1 — Response correlation
`AgentService.handleAgentResponse` keyed pending continuations on the base64-encoded payload, which can never equal the stored `requestId` — so **every** `getVMInfo`/`getVMStatus` silently timed out after 30s. It now decodes the envelope by type, recovers the real `requestId`, and correlates on it. `.statusUpdate` is split out of the correlation path (it's unsolicited).

### Phase 3b — Continuation cleanup on disconnect
Pending requests now record their target agent. `failPendingRequests(for:)` resumes a dropped agent's in-flight continuations with `.connectionLost` — wired into `unregisterAgent`, `forceUnregisterAgent`, `removeAgent`, and stale-agent eviction. Removes the continuation leak and the 30s stall on disconnect.

### Phase 2 — Real resource reporting
`getAgentResources()` returned hardcoded `8 CPU / 16 GB / 1 TB`. It now probes the host (`ProcessInfo` + `FileManager`, cross-platform) and subtracts summed VM reservations from each hypervisor service, so scheduler placement reflects reality. New `HostResources.swift` helper.

### Phase 3a — Agent auto-reconnect
The agent never reconnected after a dropped WebSocket. The close event now bridges back to the actor and starts an exponential-backoff-with-jitter reconnect loop that re-registers on success; operator-initiated disconnects are flagged so they don't reconnect.

### Phase 4 (Option A, reconcile-only) — VM state reconciliation
- `VMStatus` gains `starting`/`stopping`/`error`/`unknown`, an `isTransitional` helper, and tolerant decoding (unknown → `.unknown`). No enum migration needed — the column is plain `.string`.
- New `status_changed_at` column + migration + `VM.setStatus()` helper.
- Agent `statusUpdate` messages now persist to the DB (were dropped) — this confirms transitional → terminal.
- Heartbeat diffs `runningVMs` against DB VMs mapped to the agent: a `running`/`paused` VM absent from its agent is marked `.error`; orphans are logged. (`.created`/transitional are left alone to avoid false positives mid-create.)
- `start`/`stop` set transitional states before dispatching; a periodic sweep flips VMs stuck transitional past 120s to `.error`.
- `QEMUService` persists a VM manifest to disk on create/delete and logs previously-managed VMs as orphaned on restart (no QEMU re-adoption — that's the Option B follow-up this plumbing enables).

## Behavior changes
- `start()`/`stop()` now return `.starting`/`.stopping` and converge to the terminal state via the agent's status update + sweep (no test asserted on the old optimistic value).
- Scheduler decisions now use real host capacity.

## Testing
- Control plane: builds + **228 tests pass** (exercises the new column through the full migration chain).
- Agent: builds + **29 tests pass**.
- Shared: builds.

## Follow-ups (deliberately out of scope)
- **Option B re-adoption** — deterministic QMP socket paths + a SwiftQEMU attach API; builds on the new on-disk manifest.
- **Firecracker manifest persistence** — only `QEMUService` persists today (Firecracker's `reservedResources()` is wired).
- The pre-existing double heartbeat (Agent + WebSocketClient) is left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)