### PR TITLE
PR1: Add per-boot identity to control-plane health endpoints

### DIFF
--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -104,6 +104,14 @@ COPY --from=build --chown=vapor:vapor /staging /app
 # Provide configuration needed by the built-in crash reporter and some sensible default behaviors.
 ENV SWIFT_BACKTRACE=enable=yes,sanitize=yes,threads=all,images=all,interactive=no,swift-backtrace=./swift-backtrace-static
 
+# Build identity, surfaced on /health/* (see BuildInfo.swift). Pass via
+# `docker build --build-arg STRATO_VERSION=... --build-arg STRATO_GIT_SHA=...`.
+# Helm sets these directly in the Deployment env; defaults keep local builds honest.
+ARG STRATO_VERSION="dev"
+ARG STRATO_GIT_SHA="unknown"
+ENV STRATO_VERSION=${STRATO_VERSION}
+ENV STRATO_GIT_SHA=${STRATO_GIT_SHA}
+
 # Ensure all further commands run as the vapor user
 USER vapor:vapor
 

--- a/control-plane/Sources/App/BuildInfo.swift
+++ b/control-plane/Sources/App/BuildInfo.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Vapor
+
+/// Build-time identity of this control-plane binary.
+///
+/// Values are injected as environment variables by the Dockerfile / Helm chart
+/// (`STRATO_VERSION`, `STRATO_GIT_SHA`). When unset — e.g. a local `swift run`
+/// dev build — they fall back to sentinel values so the health endpoint never
+/// returns an empty identity.
+enum BuildInfo {
+    /// Human-readable version (e.g. a git tag or chart appVersion). "dev" when unset.
+    static let version: String = Environment.get("STRATO_VERSION") ?? "dev"
+
+    /// Git commit SHA the binary was built from. "unknown" when unset.
+    static let gitSHA: String = Environment.get("STRATO_GIT_SHA") ?? "unknown"
+}
+
+/// Per-process runtime identity captured once at boot.
+///
+/// The motivating incident: a stale duplicate control plane silently intercepted
+/// port 8080 and was indistinguishable from the real one. A per-boot `instanceId`
+/// makes two processes answering the same port trivially distinguishable, and
+/// `startedAt` ties a response back to a specific process start.
+struct InstanceIdentity: Sendable {
+    /// Unique to this process boot. Changes on every restart.
+    let instanceId: UUID
+    /// When this process captured its identity (≈ process start).
+    let startedAt: Date
+    /// Vapor environment name (development, production, testing, …).
+    let environment: String
+
+    init(environment: String) {
+        self.instanceId = UUID()
+        self.startedAt = Date()
+        self.environment = environment
+    }
+}
+
+// MARK: - Application Extension
+
+extension Application {
+    struct InstanceIdentityKey: StorageKey {
+        typealias Value = InstanceIdentity
+    }
+
+    /// The control plane's per-boot identity. Configured once in `configure.swift`.
+    var instanceIdentity: InstanceIdentity {
+        get {
+            guard let identity = self.storage[InstanceIdentityKey.self] else {
+                fatalError("InstanceIdentity not configured. Set app.instanceIdentity in configure.swift")
+            }
+            return identity
+        }
+        set {
+            self.storage[InstanceIdentityKey.self] = newValue
+        }
+    }
+}
+
+extension Request {
+    var instanceIdentity: InstanceIdentity {
+        self.application.instanceIdentity
+    }
+}

--- a/control-plane/Sources/App/Controllers/HealthController.swift
+++ b/control-plane/Sources/App/Controllers/HealthController.swift
@@ -20,13 +20,16 @@ struct HealthController: RouteCollection {
     }
 
     func liveness(req: Request) async throws -> HealthResponse {
-        // Basic liveness check - if we can respond, we're alive
+        // Basic liveness check - if we can respond, we're alive.
+        // Includes per-boot identity so callers can tell *which* control plane
+        // answered (the missing signal when a stale duplicate hijacked the port).
         return HealthResponse(
             status: "healthy",
             timestamp: Date(),
             checks: [
                 HealthCheck(name: "application", status: "up")
-            ]
+            ],
+            identity: ServiceIdentity(req.instanceIdentity)
         )
     }
 
@@ -49,7 +52,8 @@ struct HealthController: RouteCollection {
         return HealthResponse(
             status: overallStatus,
             timestamp: Date(),
-            checks: checks
+            checks: checks,
+            identity: ServiceIdentity(req.instanceIdentity)
         )
     }
 }
@@ -58,6 +62,33 @@ struct HealthResponse: Content {
     let status: String
     let timestamp: Date
     let checks: [HealthCheck]
+    let identity: ServiceIdentity?
+
+    init(status: String, timestamp: Date, checks: [HealthCheck], identity: ServiceIdentity? = nil) {
+        self.status = status
+        self.timestamp = timestamp
+        self.checks = checks
+        self.identity = identity
+    }
+}
+
+/// Identity of the control-plane process answering this request. Surfaced on the
+/// health endpoints so two instances (e.g. a stale duplicate on the same port)
+/// are immediately distinguishable by their per-boot `instanceId`.
+struct ServiceIdentity: Content {
+    let instanceId: String
+    let startedAt: Date
+    let version: String
+    let gitSHA: String
+    let environment: String
+
+    init(_ identity: InstanceIdentity) {
+        self.instanceId = identity.instanceId.uuidString
+        self.startedAt = identity.startedAt
+        self.version = BuildInfo.version
+        self.gitSHA = BuildInfo.gitSHA
+        self.environment = identity.environment
+    }
 }
 
 struct HealthCheck: Content {

--- a/control-plane/Sources/App/configure.swift
+++ b/control-plane/Sources/App/configure.swift
@@ -6,6 +6,19 @@ import OTel
 import Redis
 
 public func configure(_ app: Application) async throws {
+    // Capture this process's identity once, before anything else, so the boot log
+    // and the /health endpoints can report exactly who is answering. Two control
+    // planes on the same port will report different instanceIds — the tell we
+    // lacked when a stale duplicate silently intercepted port 8080.
+    let identity = InstanceIdentity(environment: app.environment.name)
+    app.instanceIdentity = identity
+    app.logger.info("Control plane booting", metadata: [
+        "instanceId": .string(identity.instanceId.uuidString),
+        "version": .string(BuildInfo.version),
+        "gitSHA": .string(BuildInfo.gitSHA),
+        "environment": .string(identity.environment)
+    ])
+
     // Configure Valkey if available, fallback to Fluent sessions
     if let valkeyConfig = ValkeyConfiguration.fromEnvironment() {
         do {

--- a/helm/strato-control-plane/templates/deployment.yaml
+++ b/helm/strato-control-plane/templates/deployment.yaml
@@ -113,6 +113,13 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           env:
+            # Build identity, surfaced on /health/* so a given response can be
+            # traced back to an exact version/commit. gitSHA defaults to the image
+            # tag when not set explicitly via .Values.strato.gitSHA.
+            - name: STRATO_VERSION
+              value: "{{ .Values.image.tag | default .Chart.AppVersion }}"
+            - name: STRATO_GIT_SHA
+              value: "{{ .Values.strato.gitSHA | default (.Values.image.tag | default .Chart.AppVersion) }}"
             - name: LOG_LEVEL
               value: "{{ .Values.strato.logLevel }}"
             - name: DATABASE_HOST

--- a/helm/strato-control-plane/values.yaml
+++ b/helm/strato-control-plane/values.yaml
@@ -152,7 +152,12 @@ affinity: {}
 # Strato Control Plane configuration
 strato:
   logLevel: info
-  
+
+  # Git commit SHA this image was built from, surfaced on /health/* as gitSHA.
+  # Defaults to the image tag / chart appVersion when left empty; set to the full
+  # commit SHA in CI for precise build identification.
+  gitSHA: ""
+
   database:
     host: ""  # Will be set from PostgreSQL subchart if enabled
     port: 5432


### PR DESCRIPTION
Part 1 of 4 implementing `docs/plans/01-failure-visibility.md`.

## Motivation
During the 2026-06-12 end-to-end test, a stale duplicate control plane silently intercepted port 8080 and was indistinguishable from the real one. The single change that would have collapsed the whole investigation: make the control plane say *who it is*.

## Changes
- New `BuildInfo.swift`: captures a per-boot `instanceId` (UUID) and `startedAt` (Date) at `configure` time, stored on `Application.storage`; reads `version`/`gitSHA` from `STRATO_VERSION`/`STRATO_GIT_SHA` env (falling back to `dev`/`unknown`).
- `/health/live` and `/health/ready` now return an `identity` block (`instanceId`, `startedAt`, `version`, `gitSHA`, `environment`).
- Boot log line includes the identity.
- Version/SHA plumbed through the Dockerfile build args and the Helm Deployment env (defaulting to the image tag / chart appVersion; new `strato.gitSHA` value).

## Acceptance
`curl localhost:8080/health/live` returns JSON including a per-boot `instanceId` and a `startedAt`. Restarting changes both; two instances on different ports report different identities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)