### PR TITLE
PR3: Make control-plane logs survive redirection + add request logging

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -783,7 +783,8 @@ tasks:
         fi
 
         # Start agent with SPIFFE mTLS (uses config from create-agent-config-spiffe)
-        nohup swift run --package-path "{{.PROJECT_ROOT}}/agent" StratoAgent \
+        # stdbuf -oL -eL forces line buffering so logs aren't hidden under nohup.
+        nohup stdbuf -oL -eL swift run --package-path "{{.PROJECT_ROOT}}/agent" StratoAgent \
           --config-file "{{.PROJECT_ROOT}}/config.toml" \
           --debug > /tmp/strato-agent.log 2>&1 &
         echo $! > /tmp/strato-agent.pid
@@ -887,7 +888,9 @@ tasks:
       - echo "▶️  Starting control-plane..."
       - |
         touch /tmp/strato-control-plane.log
-        cd "{{.PROJECT_ROOT}}/control-plane" && nohup swift run > /tmp/strato-control-plane.log 2>&1 &
+        # stdbuf -oL -eL forces line buffering: stdout block-buffers when it is a
+        # file (as here under nohup), which otherwise hides logs for minutes.
+        cd "{{.PROJECT_ROOT}}/control-plane" && nohup stdbuf -oL -eL swift run > /tmp/strato-control-plane.log 2>&1 &
         echo $! > /tmp/strato-control-plane.pid
       - echo "⏳ Waiting for control-plane to be ready..."
       - sleep 5
@@ -911,11 +914,12 @@ tasks:
       - echo "▶️  Starting control-plane with SPIFFE enabled..."
       - |
         touch /tmp/strato-control-plane.log
+        # stdbuf -oL -eL forces line buffering (see start-control-plane).
         cd "{{.PROJECT_ROOT}}/control-plane" && \
         SPIRE_ENABLED=true \
         SPIRE_TRUST_DOMAIN={{.SPIRE_TRUST_DOMAIN}} \
         SPIRE_TRUST_BUNDLE_PATH=/tmp/strato-spiffe/bundle.pem \
-        nohup swift run > /tmp/strato-control-plane.log 2>&1 &
+        nohup stdbuf -oL -eL swift run > /tmp/strato-control-plane.log 2>&1 &
         echo $! > /tmp/strato-control-plane.pid
       - echo "⏳ Waiting for control-plane to be ready..."
       - sleep 5
@@ -988,7 +992,8 @@ tasks:
 
         echo "▶️  Starting agent with registration URL..."
         touch /tmp/strato-agent.log
-        nohup swift run --package-path "{{.PROJECT_ROOT}}/agent" StratoAgent \
+        # stdbuf -oL -eL forces line buffering so logs aren't hidden under nohup.
+        nohup stdbuf -oL -eL swift run --package-path "{{.PROJECT_ROOT}}/agent" StratoAgent \
           --config-file "{{.PROJECT_ROOT}}/config.toml" \
           --registration-url "${REGISTRATION_URL}" > /tmp/strato-agent.log 2>&1 &
         echo $! > /tmp/strato-agent.pid
@@ -1145,7 +1150,7 @@ tasks:
             \"projectId\": \"${PROJECT_ID}\",
             \"environment\": \"development\"
           }" \
-          http://localhost:8080/vms 2>&1) || true
+          http://localhost:8080/api/vms 2>&1) || true
 
         if [ -n "$RESPONSE" ]; then
           echo "✅ VM created successfully!"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -782,9 +782,14 @@ tasks:
           exit 1
         fi
 
+        # Force line buffering so logs aren't block-buffered when redirected to a
+        # file under nohup. stdbuf is GNU coreutils (gstdbuf on macOS/Homebrew);
+        # fall back to no wrapper if neither exists so dev startup still works.
+        LINEBUF=""
+        if command -v stdbuf >/dev/null 2>&1; then LINEBUF="stdbuf -oL -eL";
+        elif command -v gstdbuf >/dev/null 2>&1; then LINEBUF="gstdbuf -oL -eL"; fi
         # Start agent with SPIFFE mTLS (uses config from create-agent-config-spiffe)
-        # stdbuf -oL -eL forces line buffering so logs aren't hidden under nohup.
-        nohup stdbuf -oL -eL swift run --package-path "{{.PROJECT_ROOT}}/agent" StratoAgent \
+        nohup $LINEBUF swift run --package-path "{{.PROJECT_ROOT}}/agent" StratoAgent \
           --config-file "{{.PROJECT_ROOT}}/config.toml" \
           --debug > /tmp/strato-agent.log 2>&1 &
         echo $! > /tmp/strato-agent.pid
@@ -888,9 +893,14 @@ tasks:
       - echo "▶️  Starting control-plane..."
       - |
         touch /tmp/strato-control-plane.log
-        # stdbuf -oL -eL forces line buffering: stdout block-buffers when it is a
-        # file (as here under nohup), which otherwise hides logs for minutes.
-        cd "{{.PROJECT_ROOT}}/control-plane" && nohup stdbuf -oL -eL swift run > /tmp/strato-control-plane.log 2>&1 &
+        # Force line buffering: stdout block-buffers when it is a file (as here
+        # under nohup), which otherwise hides logs for minutes. stdbuf is GNU
+        # coreutils (gstdbuf on macOS/Homebrew); fall back to no wrapper if neither
+        # exists so dev startup still works.
+        LINEBUF=""
+        if command -v stdbuf >/dev/null 2>&1; then LINEBUF="stdbuf -oL -eL";
+        elif command -v gstdbuf >/dev/null 2>&1; then LINEBUF="gstdbuf -oL -eL"; fi
+        cd "{{.PROJECT_ROOT}}/control-plane" && nohup $LINEBUF swift run > /tmp/strato-control-plane.log 2>&1 &
         echo $! > /tmp/strato-control-plane.pid
       - echo "⏳ Waiting for control-plane to be ready..."
       - sleep 5
@@ -914,12 +924,16 @@ tasks:
       - echo "▶️  Starting control-plane with SPIFFE enabled..."
       - |
         touch /tmp/strato-control-plane.log
-        # stdbuf -oL -eL forces line buffering (see start-control-plane).
+        # Force line buffering (see start-control-plane); no-op if stdbuf/gstdbuf
+        # is unavailable so dev startup still works.
+        LINEBUF=""
+        if command -v stdbuf >/dev/null 2>&1; then LINEBUF="stdbuf -oL -eL";
+        elif command -v gstdbuf >/dev/null 2>&1; then LINEBUF="gstdbuf -oL -eL"; fi
         cd "{{.PROJECT_ROOT}}/control-plane" && \
         SPIRE_ENABLED=true \
         SPIRE_TRUST_DOMAIN={{.SPIRE_TRUST_DOMAIN}} \
         SPIRE_TRUST_BUNDLE_PATH=/tmp/strato-spiffe/bundle.pem \
-        nohup stdbuf -oL -eL swift run > /tmp/strato-control-plane.log 2>&1 &
+        nohup $LINEBUF swift run > /tmp/strato-control-plane.log 2>&1 &
         echo $! > /tmp/strato-control-plane.pid
       - echo "⏳ Waiting for control-plane to be ready..."
       - sleep 5
@@ -992,8 +1006,12 @@ tasks:
 
         echo "▶️  Starting agent with registration URL..."
         touch /tmp/strato-agent.log
-        # stdbuf -oL -eL forces line buffering so logs aren't hidden under nohup.
-        nohup stdbuf -oL -eL swift run --package-path "{{.PROJECT_ROOT}}/agent" StratoAgent \
+        # Force line buffering so logs aren't block-buffered under nohup; no-op if
+        # stdbuf/gstdbuf is unavailable (e.g. macOS without coreutils).
+        LINEBUF=""
+        if command -v stdbuf >/dev/null 2>&1; then LINEBUF="stdbuf -oL -eL";
+        elif command -v gstdbuf >/dev/null 2>&1; then LINEBUF="gstdbuf -oL -eL"; fi
+        nohup $LINEBUF swift run --package-path "{{.PROJECT_ROOT}}/agent" StratoAgent \
           --config-file "{{.PROJECT_ROOT}}/config.toml" \
           --registration-url "${REGISTRATION_URL}" > /tmp/strato-agent.log 2>&1 &
         echo $! > /tmp/strato-agent.pid

--- a/control-plane/Sources/App/Middleware/RequestLoggingMiddleware.swift
+++ b/control-plane/Sources/App/Middleware/RequestLoggingMiddleware.swift
@@ -1,0 +1,40 @@
+import Vapor
+
+/// Emits one structured log line per HTTP request with method, path, status, and
+/// duration. Registered as the outermost middleware so the timing and status
+/// reflect the full request (including anything downstream middleware does).
+///
+/// Gated by the `REQUEST_LOGGING` env var; see `configure.swift` for the default
+/// (on outside `.production`). There was previously no request logging at all,
+/// which left the control plane silent about the traffic it was handling.
+struct RequestLoggingMiddleware: AsyncMiddleware {
+    func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
+        let start = DispatchTime.now()
+
+        func elapsedMilliseconds() -> Double {
+            let nanos = DispatchTime.now().uptimeNanoseconds &- start.uptimeNanoseconds
+            return Double(nanos) / 1_000_000
+        }
+
+        do {
+            let response = try await next.respond(to: request)
+            request.logger.info("http_request", metadata: [
+                "method": .string(request.method.rawValue),
+                "path": .string(request.url.path),
+                "status": .stringConvertible(response.status.code),
+                "durationMs": .stringConvertible(elapsedMilliseconds())
+            ])
+            return response
+        } catch {
+            // An error propagated past downstream middleware (e.g. no ErrorMiddleware
+            // converted it). Still record the request so failures aren't invisible.
+            request.logger.error("http_request_failed", metadata: [
+                "method": .string(request.method.rawValue),
+                "path": .string(request.url.path),
+                "durationMs": .stringConvertible(elapsedMilliseconds()),
+                "error": .string(String(reflecting: error))
+            ])
+            throw error
+        }
+    }
+}

--- a/control-plane/Sources/App/Middleware/RequestLoggingMiddleware.swift
+++ b/control-plane/Sources/App/Middleware/RequestLoggingMiddleware.swift
@@ -1,8 +1,15 @@
 import Vapor
 
-/// Emits one structured log line per HTTP request with method, path, status, and
-/// duration. Registered as the outermost middleware so the timing and status
-/// reflect the full request (including anything downstream middleware does).
+/// Emits exactly one structured `http_request` log line per request — method,
+/// path, status, duration — whether the request succeeded or failed.
+///
+/// On the error path the request may be turned into its HTTP response by a
+/// downstream middleware (`ErrorMiddleware`) *after* it propagates back through
+/// here as a thrown error, so we can't read the status off a `Response`. Instead
+/// we derive the status the client will ultimately see from the thrown error
+/// (`AbortError.status`, else `500`). This keeps the "one status-bearing line per
+/// request" guarantee regardless of where this middleware sits in the stack — so
+/// common 401/403/404 `Abort`s still get logged with their real status.
 ///
 /// Gated by the `REQUEST_LOGGING` env var; see `configure.swift` for the default
 /// (on outside `.production`). There was previously no request logging at all,
@@ -16,24 +23,34 @@ struct RequestLoggingMiddleware: AsyncMiddleware {
             return Double(nanos) / 1_000_000
         }
 
+        func log(status: HTTPResponseStatus, error: (any Error)? = nil) {
+            var metadata: Logger.Metadata = [
+                "method": .string(request.method.rawValue),
+                "path": .string(request.url.path),
+                "status": .stringConvertible(status.code),
+                "durationMs": .stringConvertible(elapsedMilliseconds())
+            ]
+            if let error {
+                metadata["error"] = .string(String(reflecting: error))
+            }
+            // Server-side failures are worth surfacing at error level; everything
+            // else (incl. expected 4xx) stays at info so it's one uniform line.
+            if status.code >= 500 {
+                request.logger.error("http_request", metadata: metadata)
+            } else {
+                request.logger.info("http_request", metadata: metadata)
+            }
+        }
+
         do {
             let response = try await next.respond(to: request)
-            request.logger.info("http_request", metadata: [
-                "method": .string(request.method.rawValue),
-                "path": .string(request.url.path),
-                "status": .stringConvertible(response.status.code),
-                "durationMs": .stringConvertible(elapsedMilliseconds())
-            ])
+            log(status: response.status)
             return response
         } catch {
-            // An error propagated past downstream middleware (e.g. no ErrorMiddleware
-            // converted it). Still record the request so failures aren't invisible.
-            request.logger.error("http_request_failed", metadata: [
-                "method": .string(request.method.rawValue),
-                "path": .string(request.url.path),
-                "durationMs": .stringConvertible(elapsedMilliseconds()),
-                "error": .string(String(reflecting: error))
-            ])
+            // Mirror how ErrorMiddleware maps the error to a response status so the
+            // logged status matches what the client receives, then rethrow.
+            let status = (error as? any AbortError)?.status ?? .internalServerError
+            log(status: status, error: error)
             throw error
         }
     }

--- a/control-plane/Sources/App/configure.swift
+++ b/control-plane/Sources/App/configure.swift
@@ -19,6 +19,16 @@ public func configure(_ app: Application) async throws {
         "environment": .string(identity.environment)
     ])
 
+    // Request logging: one structured line per HTTP request (method/path/status/
+    // duration). Registered first so it's the outermost middleware and times the
+    // full request. Default on outside production; override with REQUEST_LOGGING.
+    let requestLoggingEnabled = Environment.get("REQUEST_LOGGING").flatMap(Bool.init)
+        ?? (app.environment != .production)
+    if requestLoggingEnabled {
+        app.middleware.use(RequestLoggingMiddleware())
+        app.logger.info("Request logging enabled")
+    }
+
     // Configure Valkey if available, fallback to Fluent sessions
     if let valkeyConfig = ValkeyConfiguration.fromEnvironment() {
         do {

--- a/docs/deployment/logging.md
+++ b/docs/deployment/logging.md
@@ -40,6 +40,12 @@ line buffering on stdout/stderr:
 nohup stdbuf -oL -eL swift run > /tmp/strato-control-plane.log 2>&1 &
 ```
 
+`stdbuf` ships with GNU coreutils. On macOS it isn't present by default — install
+coreutils (`brew install coreutils`), where it's available as `gstdbuf` unless the
+`gnubin` PATH is added. The Taskfile detects `stdbuf`/`gstdbuf` and simply runs
+without the wrapper if neither is found, so dev startup never breaks; logs just
+fall back to block buffering on that platform.
+
 If you launch a binary by hand and redirect to a file, do the same, or `tail -f`
 a TTY instead.
 

--- a/docs/deployment/logging.md
+++ b/docs/deployment/logging.md
@@ -1,0 +1,67 @@
+# Logging & Log Visibility
+
+Operational notes on getting control-plane and agent logs to disk/console reliably,
+plus the HTTP request log. Motivated by the 2026-06-12 end-to-end test, where
+control-plane logs never reached disk because stdout was block-buffered under
+`nohup`, and the real cause of a failure was invisible until far too late.
+
+## Where logs go
+
+Both the control plane and the agent log to **stdout/stderr** via SwiftLog
+(`LoggingSystem.bootstrap`). They do not write log files themselves — capture is
+the responsibility of whatever supervises the process.
+
+### Production: run under a supervisor that captures stdout/stderr
+
+Run the control plane and agent under a process supervisor that captures their
+streams to a durable, queryable sink:
+
+- **systemd**: set `StandardOutput=journal` and `StandardError=journal` (the
+  default for most units). `journald` line-buffers and timestamps each line, so
+  there is no block-buffering problem.
+- **Kubernetes**: the container runtime captures stdout/stderr to the node log
+  and `kubectl logs` / your log shipper picks it up. The Helm chart runs the
+  binary directly as the container entrypoint, so this works out of the box.
+
+No application change is needed for this path — a console/journal sink is
+line-oriented, so logs appear promptly.
+
+### Development: line-buffer when redirecting to a file
+
+The `Taskfile.yml` dev flow runs the binaries under `nohup ... > file.log`. When
+stdout is a regular file (not a TTY), glibc **block-buffers** it, so log lines
+can sit in a 4–8 KB buffer for minutes — or be lost entirely if the process is
+killed — before reaching the file.
+
+The Taskfile works around this by launching under `stdbuf -oL -eL`, which forces
+line buffering on stdout/stderr:
+
+```sh
+nohup stdbuf -oL -eL swift run > /tmp/strato-control-plane.log 2>&1 &
+```
+
+If you launch a binary by hand and redirect to a file, do the same, or `tail -f`
+a TTY instead.
+
+## HTTP request logging (control plane)
+
+`RequestLoggingMiddleware` emits one structured line per HTTP request:
+
+```
+http_request method=GET path=/health/live status=200 durationMs=1.4
+```
+
+It is registered as the outermost middleware so the duration and status reflect
+the full request.
+
+**Toggle:** the `REQUEST_LOGGING` environment variable (`true`/`false`). When
+unset it defaults to **on outside `.production`** and off in production; set
+`REQUEST_LOGGING=true` to enable it in production for debugging.
+
+## Service identity on the health endpoints
+
+`GET /health/live` and `GET /health/ready` include an `identity` object
+(`instanceId`, `startedAt`, `version`, `gitSHA`, `environment`). `instanceId` is
+unique per process boot, so two control planes answering the same port are
+immediately distinguishable — the signal that was missing when a stale duplicate
+silently intercepted port 8080. See `BuildInfo.swift`.

--- a/docs/deployment/logging.md
+++ b/docs/deployment/logging.md
@@ -57,8 +57,11 @@ a TTY instead.
 http_request method=GET path=/health/live status=200 durationMs=1.4
 ```
 
-It is registered as the outermost middleware so the duration and status reflect
-the full request.
+Failed requests are logged too: a thrown `Abort` (401/403/404/…) propagates back
+through the middleware as an error, so the status is derived from the error
+(`AbortError.status`, else `500`) to match what the client receives. `5xx`
+responses are logged at `error` level, everything else at `info` — always as the
+same `http_request` event, so it's one status-bearing line per request.
 
 **Toggle:** the `REQUEST_LOGGING` environment variable (`true`/`false`). When
 unset it defaults to **on outside `.production`** and off in production; set

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,3 +72,4 @@ Strato uses a distributed **Control Plane** and **Agent** architecture:
 - [Architecture Overview](/architecture/overview)
 - [Development with Skaffold](/development/skaffold)
 - [Deployment Guide](/deployment/overview)
+- [Logging & Log Visibility](/deployment/logging)


### PR DESCRIPTION
Part 3 of 4 implementing `docs/plans/01-failure-visibility.md`.

## Motivation
Two log-visibility gaps from the 2026-06-12 end-to-end test: control-plane logs never reached disk (stdout block-buffers when redirected to a file under `nohup`), and there was no HTTP request logging at all.

## Changes
- **Request logging:** new `RequestLoggingMiddleware` emits one structured line per request (`method`/`path`/`status`/`durationMs`), registered as the outermost middleware. Gated by `REQUEST_LOGGING`; defaults on outside `.production`.
- **Logs survive redirection:** the dev Taskfile launches the control plane and agent under `stdbuf -oL -eL` to force line buffering. Production captures stdout via a supervisor (systemd journal / k8s), which is line-oriented already.
- New `docs/deployment/logging.md` documents the production supervisor path, the dev line-buffering, the request log, and the health-endpoint identity.

## Acceptance
With request logging on, every HTTP request produces one structured log line. Control-plane logs appear promptly (no multi-minute buffering) under the dev Taskfile.

## Note
The Taskfile change also carries a pre-existing working-tree fix that predated this work: VM-create POST to `/api/vms` instead of `/vms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)