### PR TITLE
PR4: Emit production telemetry for agent/VM failure modes + alert runbook

### DIFF
--- a/control-plane/Package.swift
+++ b/control-plane/Package.swift
@@ -33,6 +33,8 @@ let package = Package(
         .package(url: "https://github.com/swift-server/swift-openapi-vapor.git", from: "1.0.0"),
         // 📊 OpenTelemetry observability (metrics, logging, tracing)
         .package(url: "https://github.com/swift-otel/swift-otel.git", from: "1.0.0"),
+        // 📈 swift-metrics facade (backed by swift-otel when OTEL_METRICS_ENABLED)
+        .package(url: "https://github.com/apple/swift-metrics.git", from: "2.0.0"),
         // 🔴 Valkey/Redis support for caching and sessions
         .package(url: "https://github.com/vapor/redis.git", from: "4.0.0")
     ],
@@ -56,6 +58,7 @@ let package = Package(
                 .product(name: "OpenAPIVapor", package: "swift-openapi-vapor"),
                 .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
                 .product(name: "OTel", package: "swift-otel"),
+                .product(name: "Metrics", package: "swift-metrics"),
                 .product(name: "Redis", package: "redis")
             ],
             swiftSettings: swiftSettings,

--- a/control-plane/Sources/App/Controllers/AgentWebSocketController.swift
+++ b/control-plane/Sources/App/Controllers/AgentWebSocketController.swift
@@ -236,12 +236,14 @@ struct AgentWebSocketController: RouteCollection {
 
         return query.flatMapThrowing { registrationToken -> Bool in
             guard let registrationToken = registrationToken else {
+                Telemetry.agentRegistrationFailed(reason: "invalid_token")
                 self.sendErrorResponse(ws: ws, requestId: "", error: "Invalid registration token")
                 _ = ws.close(code: .unacceptableData)
                 return false
             }
 
             guard registrationToken.isValid else {
+                Telemetry.agentRegistrationFailed(reason: "expired_token")
                 self.sendErrorResponse(ws: ws, requestId: "", error: "Registration token is invalid or expired")
                 _ = ws.close(code: .unacceptableData)
                 return false
@@ -320,6 +322,7 @@ struct AgentWebSocketController: RouteCollection {
                         )
                         self.sendMessage(ws: ws, message: response)
                     } catch {
+                        Telemetry.agentRegistrationFailed(reason: "register_error")
                         req.logger.error("Failed to register agent: \(error)")
                         self.sendErrorResponse(ws: ws, requestId: message.requestId, error: "Failed to register agent: \(error.localizedDescription)")
                     }

--- a/control-plane/Sources/App/Services/AgentService.swift
+++ b/control-plane/Sources/App/Services/AgentService.swift
@@ -145,6 +145,7 @@ actor AgentService {
         agents[agentUUID.uuidString] = agentInfo
 
         Telemetry.agentConnected()
+        Telemetry.recordAgentUp(agentName: agentName, up: true)
         app.logger.info("Agent registered", metadata: [
             "agentId": .string(agentUUID.uuidString),
             "agentName": .string(agentName),
@@ -192,6 +193,9 @@ actor AgentService {
         }
 
         Telemetry.agentDisconnected(reason: "unregister")
+        if let name = agentName {
+            Telemetry.recordAgentUp(agentName: name, up: false)
+        }
         app.logger.info("Agent unregistered", metadata: ["agentId": .string(agentId)])
     }
 
@@ -235,6 +239,7 @@ actor AgentService {
         agents.removeValue(forKey: agentId)
 
         Telemetry.agentDisconnected(reason: "connection_closed")
+        Telemetry.recordAgentUp(agentName: agentName, up: false)
 
         // Update database status asynchronously
         Task {
@@ -412,10 +417,17 @@ actor AgentService {
                 // Fail any in-flight requests waiting on this agent before we drop it
                 failPendingRequests(for: agentId)
 
+                // Capture the name before removal so the up/down gauge keeps a
+                // durable `0` for this specific agent after it leaves memory.
+                let staleAgentName = agents[agentId]?.name
+
                 // Remove from memory
                 agents.removeValue(forKey: agentId)
 
                 Telemetry.agentDisconnected(reason: "stale")
+                if let name = staleAgentName {
+                    Telemetry.recordAgentUp(agentName: name, up: false)
+                }
 
                 // Update database using UUID
                 Task {

--- a/control-plane/Sources/App/Services/AgentService.swift
+++ b/control-plane/Sources/App/Services/AgentService.swift
@@ -144,6 +144,7 @@ actor AgentService {
 
         agents[agentUUID.uuidString] = agentInfo
 
+        Telemetry.agentConnected()
         app.logger.info("Agent registered", metadata: [
             "agentId": .string(agentUUID.uuidString),
             "agentName": .string(agentName),
@@ -190,6 +191,7 @@ actor AgentService {
             vmToAgentMapping.removeValue(forKey: vmId)
         }
 
+        Telemetry.agentDisconnected(reason: "unregister")
         app.logger.info("Agent unregistered", metadata: ["agentId": .string(agentId)])
     }
 
@@ -231,6 +233,8 @@ actor AgentService {
 
         // Mark agent as offline in memory
         agents.removeValue(forKey: agentId)
+
+        Telemetry.agentDisconnected(reason: "connection_closed")
 
         // Update database status asynchronously
         Task {
@@ -331,6 +335,7 @@ actor AgentService {
                 vm.setStatus(.error)
                 try await vm.save(on: db)
                 divergent += 1
+                Telemetry.vmEnteredError(reason: "reconciliation")
 
                 app.logger.warning("VM missing from agent heartbeat; marking as error", metadata: [
                     "vmId": .string(vmId),
@@ -384,6 +389,15 @@ actor AgentService {
         let now = Date()
         let staleThreshold: TimeInterval = 60 // 60 seconds
 
+        // Export per-agent heartbeat staleness as a gauge every cycle so alerting
+        // can watch an agent go quiet before the sweep removes it.
+        for agentInfo in agents.values {
+            Telemetry.recordHeartbeatStaleness(
+                agentName: agentInfo.name,
+                seconds: now.timeIntervalSince(agentInfo.lastHeartbeat)
+            )
+        }
+
         let staleAgents = agents.values.compactMap { agentInfo -> String? in
             if now.timeIntervalSince(agentInfo.lastHeartbeat) > staleThreshold {
                 return agentInfo.id  // This is the UUID
@@ -400,6 +414,8 @@ actor AgentService {
 
                 // Remove from memory
                 agents.removeValue(forKey: agentId)
+
+                Telemetry.agentDisconnected(reason: "stale")
 
                 // Update database using UUID
                 Task {
@@ -441,6 +457,7 @@ actor AgentService {
                 let previous = vm.status
                 vm.setStatus(.error)
                 try await vm.save(on: db)
+                Telemetry.vmEnteredError(reason: "stuck_transition")
 
                 app.logger.warning("VM stuck in transitional state past timeout; marking as error", metadata: [
                     "vmId": .string(vm.id?.uuidString ?? ""),
@@ -797,6 +814,10 @@ actor AgentService {
                 let previous = vm.status
                 vm.setStatus(update.status)
                 try await vm.save(on: app.db)
+                if update.status == .error {
+                    // The agent pushed an error state — e.g. a failed create/boot.
+                    Telemetry.vmEnteredError(reason: "agent_reported")
+                }
 
                 app.logger.info("Applied agent status update", metadata: [
                     "vmId": .string(update.vmId),

--- a/control-plane/Sources/App/Telemetry/Telemetry.swift
+++ b/control-plane/Sources/App/Telemetry/Telemetry.swift
@@ -1,0 +1,51 @@
+import Metrics
+
+/// Central definitions for the operational metrics surfaced for production
+/// observability and alerting. Routing all emission through these helpers keeps
+/// metric names and label keys consistent across call sites.
+///
+/// These use the swift-metrics facade. When OpenTelemetry is bootstrapped
+/// (`OTEL_METRICS_ENABLED=true`, see `configure.swift`) the facade is backed by
+/// the OTLP exporter; otherwise swift-metrics defaults to a no-op backend and
+/// every call here is a cheap no-op — so call sites need no feature gating.
+///
+/// See `docs/deployment/observability.md` for the alert runbook built on these.
+enum Telemetry {
+
+    // MARK: - Agent lifecycle
+
+    /// An agent successfully (re)registered with the control plane.
+    static func agentConnected() {
+        Counter(label: "strato_agent_connections_total").increment()
+    }
+
+    /// An agent connection went away. `reason` distinguishes the cause:
+    /// `connection_closed` (socket dropped), `unregister` (graceful shutdown),
+    /// or `stale` (heartbeats stopped, swept by the monitor).
+    static func agentDisconnected(reason: String) {
+        Counter(label: "strato_agent_disconnections_total", dimensions: [("reason", reason)]).increment()
+    }
+
+    /// A registration attempt was rejected. `reason` is e.g. `invalid_token`,
+    /// `expired_token`, or `register_error`.
+    static func agentRegistrationFailed(reason: String) {
+        Counter(label: "strato_agent_registration_failures_total", dimensions: [("reason", reason)]).increment()
+    }
+
+    /// Seconds since an agent's last heartbeat, recorded per agent each monitoring
+    /// cycle. Alert when this climbs past the staleness threshold — a quiet agent
+    /// is the early signal of a hung or partitioned hypervisor node.
+    static func recordHeartbeatStaleness(agentName: String, seconds: Double) {
+        Gauge(label: "strato_agent_heartbeat_staleness_seconds", dimensions: [("agent", agentName)]).record(seconds)
+    }
+
+    // MARK: - VM health
+
+    /// A VM transitioned into the `.error` state. `reason` records which mechanism
+    /// caught it: `reconciliation` (missing from an agent heartbeat),
+    /// `stuck_transition` (timed out mid start/stop), or `agent_reported` (the
+    /// agent pushed an error status, e.g. a failed create/boot).
+    static func vmEnteredError(reason: String) {
+        Counter(label: "strato_vm_errors_total", dimensions: [("reason", reason)]).increment()
+    }
+}

--- a/control-plane/Sources/App/Telemetry/Telemetry.swift
+++ b/control-plane/Sources/App/Telemetry/Telemetry.swift
@@ -32,9 +32,20 @@ enum Telemetry {
         Counter(label: "strato_agent_registration_failures_total", dimensions: [("reason", reason)]).increment()
     }
 
+    /// Per-agent connection state: `1` while connected, `0` once disconnected.
+    /// This is the durable, alertable signal — unlike the staleness gauge it keeps
+    /// reporting `0` after the stale sweep drops the agent from memory, so an alert
+    /// like `strato_agent_up == 0 for 5m` actually fires, and the `agent` label
+    /// identifies exactly which node is down. Set to `1` on (re)registration and
+    /// `0` on every disconnect path (close / unregister / stale sweep).
+    static func recordAgentUp(agentName: String, up: Bool) {
+        Gauge(label: "strato_agent_up", dimensions: [("agent", agentName)]).record(up ? 1 : 0)
+    }
+
     /// Seconds since an agent's last heartbeat, recorded per agent each monitoring
-    /// cycle. Alert when this climbs past the staleness threshold — a quiet agent
-    /// is the early signal of a hung or partitioned hypervisor node.
+    /// cycle *while the agent is still connected*. A secondary signal for spotting
+    /// heartbeats that are slowing before the 60s sweep removes the agent; once
+    /// swept it stops updating, so alert on `strato_agent_up` for hard-down detection.
     static func recordHeartbeatStaleness(agentName: String, seconds: Double) {
         Gauge(label: "strato_agent_heartbeat_staleness_seconds", dimensions: [("agent", agentName)]).record(seconds)
     }

--- a/docs/deployment/observability.md
+++ b/docs/deployment/observability.md
@@ -33,7 +33,8 @@ All metrics are defined in one place: `control-plane/Sources/App/Telemetry/Telem
 | `strato_agent_connections_total` | counter | — | Agent successfully (re)registered |
 | `strato_agent_disconnections_total` | counter | `reason` = `connection_closed` \| `unregister` \| `stale` | Agent connection ended |
 | `strato_agent_registration_failures_total` | counter | `reason` = `invalid_token` \| `expired_token` \| `register_error` | A registration attempt was rejected |
-| `strato_agent_heartbeat_staleness_seconds` | gauge | `agent` = agent name | Seconds since the agent's last heartbeat (recorded every ~30s monitoring cycle) |
+| `strato_agent_up` | gauge | `agent` = agent name | `1` while connected, `0` once disconnected. Durable per-agent up/down signal — keeps reporting `0` after the stale sweep, so it's the basis for the "agent down" alert |
+| `strato_agent_heartbeat_staleness_seconds` | gauge | `agent` = agent name | Seconds since the agent's last heartbeat, recorded each ~30s cycle **while connected**. Secondary "heartbeats slowing" signal; stops updating once the agent is swept |
 | `strato_vm_errors_total` | counter | `reason` = `reconciliation` \| `stuck_transition` \| `agent_reported` | A VM transitioned into `.error` |
 
 ### Notes on the labels
@@ -55,11 +56,12 @@ Thresholds are starting points; tune to your fleet size and SLOs.
 
 ### Agent disconnected too long
 
-- **Condition:** an agent has no connection for more than **N minutes**
-  (suggest 5 min). Derive from `strato_agent_heartbeat_staleness_seconds`
-  climbing past `300`, or absence of a connection after a
-  `strato_agent_disconnections_total` increment with no following
-  `strato_agent_connections_total` for the same fleet.
+- **Condition:** `strato_agent_up == 0` for more than **N minutes** (suggest
+  5 min) — e.g. `min_over_time(strato_agent_up[5m]) == 0`. The `agent` label names
+  the down node. Use this gauge, **not** `strato_agent_heartbeat_staleness_seconds`:
+  the staleness gauge stops updating once the 60s stale sweep removes the agent
+  from memory, so it never climbs to a 5-minute threshold. `strato_agent_up` keeps
+  reporting `0` after the sweep, so the alert actually fires.
 - **Severity:** warning at 5 min, page at 15 min (capacity loss / VMs unmanaged).
 - **First checks:** is the agent process alive on the node? Network path to the
   control plane? Look for `register_error` / token issues in
@@ -100,8 +102,9 @@ The dev Taskfile disables OTel. To exercise metrics, run the control plane with
 `OTEL_METRICS_ENABLED=true` and an OTLP collector (the Taskfile's
 `start-otel-collector` brings one up), then:
 
-- Kill an agent → expect a `strato_agent_disconnections_total{reason="stale"}`
-  (or `connection_closed`) increment and `strato_agent_heartbeat_staleness_seconds`
-  climbing for that agent.
+- Kill an agent → expect `strato_agent_up{agent="…"}` to drop to `0` (and stay
+  there) and a `strato_agent_disconnections_total{reason="stale"}` (or
+  `connection_closed`) increment. While it's still in the 60s grace window,
+  `strato_agent_heartbeat_staleness_seconds` climbs before the sweep removes it.
 - Trigger a VM failure → expect `strato_vm_errors_total` to increment with the
   matching `reason`.

--- a/docs/deployment/observability.md
+++ b/docs/deployment/observability.md
@@ -1,0 +1,107 @@
+# Observability: Metrics & Alerts
+
+The control plane emits OpenTelemetry metrics for the failure modes that the
+2026-06-12 end-to-end test made painful to diagnose: agents silently going away,
+heartbeats drying up, and VMs landing in `.error` without anyone noticing.
+
+This page is the catalog of those metrics and the alert runbook built on them.
+
+## Enabling metrics
+
+Metrics flow through the swift-metrics facade, backed by the OTLP exporter when
+OpenTelemetry is bootstrapped. Controlled by environment variables (see
+`configure.swift`):
+
+| Variable | Default | Notes |
+|----------|---------|-------|
+| `OTEL_METRICS_ENABLED` | `true` (except dev Taskfile, which disables it) | Master switch for metric export |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `localhost:4317` (gRPC) | Where to ship OTLP |
+| `OTEL_SERVICE_NAME` | `strato-control-plane` | `service.name` resource attribute |
+
+When metrics are disabled, swift-metrics uses a no-op backend — emission call
+sites stay in the code but cost nothing.
+
+Production should run with `OTEL_METRICS_ENABLED=true` pointed at a collector.
+The Helm chart wires this via the `opentelemetry.*` values.
+
+## Metric catalog
+
+All metrics are defined in one place: `control-plane/Sources/App/Telemetry/Telemetry.swift`.
+
+| Metric | Type | Labels | Meaning |
+|--------|------|--------|---------|
+| `strato_agent_connections_total` | counter | — | Agent successfully (re)registered |
+| `strato_agent_disconnections_total` | counter | `reason` = `connection_closed` \| `unregister` \| `stale` | Agent connection ended |
+| `strato_agent_registration_failures_total` | counter | `reason` = `invalid_token` \| `expired_token` \| `register_error` | A registration attempt was rejected |
+| `strato_agent_heartbeat_staleness_seconds` | gauge | `agent` = agent name | Seconds since the agent's last heartbeat (recorded every ~30s monitoring cycle) |
+| `strato_vm_errors_total` | counter | `reason` = `reconciliation` \| `stuck_transition` \| `agent_reported` | A VM transitioned into `.error` |
+
+### Notes on the labels
+
+- **`strato_agent_disconnections_total{reason}`** — `connection_closed` is the
+  WebSocket close handler, `unregister` is a graceful agent shutdown, `stale` is
+  the heartbeat monitor sweeping an agent that went quiet for >60s.
+- **`strato_vm_errors_total{reason}`** — `reconciliation` fires when a VM the DB
+  maps to an agent is absent from that agent's heartbeat; `stuck_transition`
+  fires when a VM sits in `.starting`/`.stopping` past the 120s timeout;
+  `agent_reported` fires when an agent pushes an `.error` status (e.g. a failed
+  create or boot). A failed VM create surfaces as `agent_reported` if the agent
+  reports it, otherwise as `reconciliation` once the VM goes missing from a
+  heartbeat — check the control-plane logs (`http_request` / warnings) alongside.
+
+## Alert runbook
+
+Thresholds are starting points; tune to your fleet size and SLOs.
+
+### Agent disconnected too long
+
+- **Condition:** an agent has no connection for more than **N minutes**
+  (suggest 5 min). Derive from `strato_agent_heartbeat_staleness_seconds`
+  climbing past `300`, or absence of a connection after a
+  `strato_agent_disconnections_total` increment with no following
+  `strato_agent_connections_total` for the same fleet.
+- **Severity:** warning at 5 min, page at 15 min (capacity loss / VMs unmanaged).
+- **First checks:** is the agent process alive on the node? Network path to the
+  control plane? Look for `register_error` / token issues in
+  `strato_agent_registration_failures_total` (an agent stuck in a reconnect loop
+  with a bad token will show rising registration failures).
+
+### Any VM in `.error`
+
+- **Condition:** `increase(strato_vm_errors_total[15m]) > 0`, or a nonzero count
+  of VMs in `.error` in the database.
+- **Severity:** warning (operator attention), page if many VMs flip at once
+  (likely an agent crash taking its VMs down).
+- **First checks:** the `reason` label points at the mechanism. `reconciliation`
+  / `agent_reported` in bulk for one agent ⇒ that agent crashed or lost its VMs;
+  cross-reference `strato_agent_disconnections_total`. `stuck_transition` ⇒ an
+  operation's terminal confirmation never arrived (lost status update or an agent
+  that died mid-op).
+
+### Registration failures spiking
+
+- **Condition:** `increase(strato_agent_registration_failures_total[10m])`
+  above a small threshold.
+- **Severity:** warning. A burst of `invalid_token` / `expired_token` usually
+  means a misconfigured or restarting agent presenting a stale token; a burst of
+  `register_error` points at a control-plane/database problem.
+
+### Readiness probe failing
+
+- **Condition:** `GET /health/ready` returns non-`healthy` (database check down).
+- **Severity:** page — the control plane cannot serve requests reliably.
+- **First checks:** database connectivity; the `identity` block in the health
+  response confirms *which* instance is failing (see
+  [Logging & Log Visibility](/deployment/logging)).
+
+## Verifying locally
+
+The dev Taskfile disables OTel. To exercise metrics, run the control plane with
+`OTEL_METRICS_ENABLED=true` and an OTLP collector (the Taskfile's
+`start-otel-collector` brings one up), then:
+
+- Kill an agent → expect a `strato_agent_disconnections_total{reason="stale"}`
+  (or `connection_closed`) increment and `strato_agent_heartbeat_staleness_seconds`
+  climbing for that agent.
+- Trigger a VM failure → expect `strato_vm_errors_total` to increment with the
+  matching `reason`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,3 +73,4 @@ Strato uses a distributed **Control Plane** and **Agent** architecture:
 - [Development with Skaffold](/development/skaffold)
 - [Deployment Guide](/deployment/overview)
 - [Logging & Log Visibility](/deployment/logging)
+- [Observability: Metrics & Alerts](/deployment/observability)


### PR DESCRIPTION
Part 4 of 4 implementing `docs/plans/01-failure-visibility.md`.

## Motivation
Add OpenTelemetry metrics for the failure modes the 2026-06-12 end-to-end test made hard to diagnose: agents silently going away, heartbeats drying up, and VMs landing in `.error` without anyone noticing. Plus a documented alert runbook.

## Changes
All emission routed through a single `Telemetry` helper (swift-metrics facade; a no-op when `OTEL_METRICS_ENABLED` is off, so call sites need no gating):

- `strato_agent_connections_total` / `strato_agent_disconnections_total{reason}` — hooked into `registerAgent`, `removeAgent`, `unregisterAgent`, and the stale sweep.
- `strato_agent_registration_failures_total{reason}` — token-validation and register failures in `AgentWebSocketController`.
- `strato_agent_heartbeat_staleness_seconds{agent}` — gauge recorded per agent each monitoring cycle.
- `strato_vm_errors_total{reason}` — incremented wherever a VM flips to `.error` (reconciliation, stuck-transition sweep, agent-reported status).

Adds `swift-metrics` as a direct dependency (already resolved transitively via swift-otel). New `docs/deployment/observability.md` documents the metric catalog + alert runbook (agent disconnected > N min; any VM in `.error`; registration-failure spikes; readiness probe failing). Helm already defaults OTel metrics on, so production runs with it enabled.

## Acceptance
With `OTEL_METRICS_ENABLED=true`, killing an agent produces a disconnect event and a rising staleness gauge; a VM failure increments `strato_vm_errors_total` with the matching `reason`. Dashboards/alerts documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)